### PR TITLE
Adding spherical harmonic map interface

### DIFF
--- a/src/jaxoplanet/experimental/starry/wigner3j.py
+++ b/src/jaxoplanet/experimental/starry/wigner3j.py
@@ -1,0 +1,395 @@
+"""The code in this submodule is taken directly from the MIT-licensed
+'spherical' package. Below is the original license text:
+
+Copyright (c) 2021 Mike Boyle
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+"""
+
+import math
+
+import numpy as np
+
+
+def A(j, j2, j3, m1):
+    return math.sqrt(
+        (j**2 - (j2 - j3) ** 2) * ((j2 + j3 + 1) ** 2 - j**2) * (j**2 - m1**2)
+    )
+
+
+def B(j, j2, j3, m2, m3):
+    return (2 * j + 1) * (
+        (m2 + m3) * (j2 * (j2 + 1) - j3 * (j3 + 1)) - (m2 - m3) * j * (j + 1)
+    )
+
+
+def Xf(j, j2, j3, m1):
+    return j * A(j + 1, j2, j3, m1)
+
+
+Yf = B
+
+
+def Zf(j, j2, j3, m1):
+    return (j + 1) * A(j, j2, j3, m1)
+
+
+def normalize(f, j_min, j_max):
+    norm = 0.0
+    for j in range(j_min, j_max + 1):
+        norm += (2 * j + 1) * f[j] ** 2
+    f[j_min : j_max + 1] /= math.sqrt(norm)
+
+
+def determine_signs(f, j_min, j_max, j2, j3, m2, m3):
+    if (f[j_max] < 0.0 and (-1) ** (j2 - j3 + m2 + m3) > 0) or (
+        f[j_max] > 0.0 and (-1) ** (j2 - j3 + m2 + m3) < 0
+    ):
+        f[j_min : j_max + 1] *= -1.0
+
+
+class Wigner3jCalculator:
+    def __init__(self, j2_max, j3_max):
+        self._size = j2_max + j3_max + 1
+        self.workspace = np.zeros(4 * self._size, dtype=np.float64)
+
+    @property
+    def size(self):
+        return self._size
+
+    def calculate(self, j2, j3, m2, m3):
+        """Compute Wigner 3-j symbols
+
+        For given values of j₂, j₃, m₂, m₃, this computes all valid values of
+
+            ⎛j₁  j₂  j₃⎞   _   ⎛j₂  j₃  j₁⎞   _   ⎛j₃  j₁  j₂⎞
+            ⎝m₁  m₂  m₃⎠   -   ⎝m₂  m₃  m₁⎠   -   ⎝m₃  m₁  m₂⎠
+
+        The valid values have m₁=-m₂-m₃ and j₁ ranging from max(|j₂-j₃|, |m₁|) to j₂+j₃.
+        The calculation uses the approach described by Luscombe and Luban (1998)
+        <https://doi.org/10.1103/PhysRevE.57.7274>, which is a recurrence method, leading
+        to significant gains in speed and accuracy.
+
+        The returned array is a slice of this object's `workspace` array, and so will not
+        remain the same between calls to this function.  If you want to keep a copy of
+        the results, explicitly call the `numpy.copy` method.
+
+        The returned array is indexed by j₁.  In particular, note that some invalid
+        j₁ indices are accessible, but have value 0.0.
+
+        This implementation uses several tricks gleaned from the Fortran code in
+        <https://github.com/SHTOOLS/SHTOOLS>, which also implements the Luscombe-Luban
+        algorithm.  In particular, that code (and now this code) treats several special
+        cases that were not clearly specified by Luscombe-Luban.
+
+        To use this object, do something like this:
+
+            # Try to do this just once because it allocates memory, which is slow
+            calculator = Wigner3jCalculator(j2_max, j3_max)
+
+            # Presumably, the following is inside some loop over j2, j3, m2, m3
+            w3j = calculator.calculate(j2, j3, m2, m3)
+            m1 = - m2 - m3
+            for j1 in range(max(abs(j2-j3), abs(m1)), j2+j3+1):
+                w3j[j1]  # This is the value of the 3-j symbol written above
+
+        Again, the array w3j contains accessible memory outside of the bounds of j1 given
+        in the above loop, but those values will all be 0.0.
+
+        """
+        m1 = -(m2 + m3)
+
+        undefined_min = False
+        undefined_max = False
+        scale_factor = 1_000.0
+
+        # Set up the workspace
+        self.workspace[:] = 0.0
+        f = self.workspace[: self.size]
+        sf = self.workspace[self.size : 2 * self.size]
+        rf = sf  # An alias for the same memory as `sf`
+        F_minus = self.workspace[2 * self.size : 3 * self.size]
+        F_plus = self.workspace[3 * self.size : 4 * self.size]
+
+        # Calculate some useful bounds
+        j_min = max(abs(j2 - j3), abs(m2 + m3))
+        j_max = j2 + j3
+
+        # Skip all calculations if there are no nonzero elements
+        if abs(m2) > j2 or abs(m3) > j3:
+            return f
+        if j_max < j_min:
+            return f
+
+        # When only one term is present, we have a simple formula
+        if j_max == j_min:
+            f[j_min] = 1.0 / math.sqrt(2.0 * j_min + 1.0)
+            if (f[j_min] < 0.0 and (-1) ** (j2 - j3 + m2 + m3) > 0) or (
+                f[j_min] > 0.0 and (-1) ** (j2 - j3 + m2 + m3) < 0
+            ):
+                f[j_min] *= -1.0
+            return f
+
+        ##########################################################################
+        # Forward iteration over first "nonclassical" region j_min ≤ j ≤ j_minus #
+        ##########################################################################
+        Xf_j_min = Xf(j_min, j2, j3, m1)
+        Yf_j_min = Yf(j_min, j2, j3, m2, m3)
+
+        if m1 == 0 and m2 == 0 and m3 == 0:
+            # Recurrence is undefined, but it's okay because all odd terms must be zero
+            F_minus[j_min] = 1.0
+            F_minus[j_min + 1] = 0.0
+            j_minus = j_min + 1
+
+        elif Yf_j_min == 0.0:
+            # The second term is either undefined or zero
+            if Xf_j_min == 0.0:
+                undefined_min = True
+                j_minus = j_min
+            else:
+                F_minus[j_min] = 1.0
+                F_minus[j_min + 1] = 0.0
+                j_minus = j_min + 1
+
+        elif Xf_j_min * Yf_j_min >= 0.0:
+            # The second term is already in the classical region
+            F_minus[j_min] = 1.0
+            F_minus[j_min + 1] = -Yf_j_min / Xf_j_min
+            j_minus = j_min + 1
+
+        else:
+            # Use recurrence relation, Eq. (3) from Luscombe and Luban (1998)
+            sf[j_min] = -Xf_j_min / Yf_j_min
+            j_minus = j_max
+            for j in range(j_min + 1, j_max):
+                denominator = Yf(j, j2, j3, m2, m3) + Zf(j, j2, j3, m1) * sf[j - 1]
+                Xf_j = Xf(j, j2, j3, m1)
+                if (
+                    abs(Xf_j) > abs(denominator)
+                    or Xf_j * denominator >= 0.0
+                    or denominator == 0.0
+                ):
+                    j_minus = j - 1
+                    break
+                else:
+                    sf[j] = -Xf_j / denominator
+            F_minus[j_minus] = 1.0
+            for k in range(1, j_minus - j_min + 1):
+                F_minus[j_minus - k] = F_minus[j_minus - k + 1] * sf[j_minus - k]
+            if j_minus == j_min:
+                # Calculate at least two terms so that these can be used in three-term
+                # recursion
+                F_minus[j_min + 1] = -Yf_j_min / Xf_j_min
+                j_minus = j_min + 1
+
+        if j_minus == j_max:
+            # We're finished!
+            f[j_min : j_max + 1] = F_minus[j_min : j_max + 1]
+            normalize(f, j_min, j_max)
+            determine_signs(f, j_min, j_max, j2, j3, m2, m3)
+            return f
+
+        ##########################################################################
+        # Reverse iteration over second "nonclassical" region j_plus ≤ j ≤ j_max #
+        ##########################################################################
+        Yf_j_max = Yf(j_max, j2, j3, m2, m3)
+        Zf_j_max = Zf(j_max, j2, j3, m1)
+
+        if m1 == 0 and m2 == 0 and m3 == 0:
+            # Recurrence is undefined, but it's okay because all odd terms must be zero
+            F_plus[j_max] = 1.0
+            F_plus[j_max - 1] = 0.0
+            j_plus = j_max - 1
+
+        elif Yf_j_max == 0.0:
+            # The second term is either undefined or zero
+            if Zf_j_max == 0.0:
+                undefined_max = True
+                j_plus = j_max
+            else:
+                F_plus[j_max] = 1.0
+                F_plus[j_max - 1] = -Yf_j_max / Zf_j_max
+                j_plus = j_max - 1
+
+        elif Yf_j_max * Zf_j_max >= 0.0:
+            # The second term is already in the classical region
+            F_plus[j_max] = 1.0
+            F_plus[j_max - 1] = -Yf_j_max / Zf_j_max
+            j_plus = j_max - 1
+
+        else:
+            # Use recurrence relation, Eq. (2) from Luscombe and Luban (1998)
+            rf[j_max] = -Zf_j_max / Yf_j_max
+            j_plus = j_min
+            for j in range(j_max - 1, j_minus - 1, -1):
+                denominator = Yf(j, j2, j3, m2, m3) + Xf(j, j2, j3, m1) * rf[j + 1]
+                Zf_j = Zf(j, j2, j3, m1)
+                if (
+                    denominator == 0.0
+                    or abs(Zf_j) > abs(denominator)
+                    or Zf_j * denominator >= 0.0
+                ):
+                    j_plus = j + 1
+                    break
+                else:
+                    rf[j] = -Zf_j / denominator
+            F_plus[j_plus] = 1.0
+            for k in range(1, j_max - j_plus + 1):
+                F_plus[j_plus + k] = F_plus[j_plus + k - 1] * rf[j_plus + k]
+            if j_plus == j_max:
+                F_plus[j_max - 1] = -Yf_j_max / Zf_j_max
+                j_plus = j_max - 1
+
+        ######################################################################
+        # Three-term recurrence over "classical" region j_minus ≤ j ≤ j_plus #
+        ######################################################################
+        if undefined_min and undefined_max:
+            raise ValueError(
+                "Cannot initialize recurrence in Wigner3jCalculator.calculate"
+            )
+
+        if not undefined_min and not undefined_max:
+            # Iterate upwards and downwards, meeting in the middle
+            j_mid = (j_minus + j_plus) // 2
+            for j in range(j_minus, j_mid):
+                F_minus[j + 1] = -(
+                    Yf(j, j2, j3, m2, m3) * F_minus[j]
+                    + Zf(j, j2, j3, m1) * F_minus[j - 1]
+                ) / Xf(j, j2, j3, m1)
+                if abs(F_minus[j + 1]) > 1.0:
+                    F_minus[j_min : j + 1 + 1] /= scale_factor
+                if abs(F_minus[j + 1] / F_minus[j - 1]) < 1.0 and F_minus[j + 1] != 0.0:
+                    j_mid = j + 1
+                    break
+            F_minus_j_mid = F_minus[j_mid]
+            if (
+                F_minus[j_mid - 1] != 0.0
+                and abs(F_minus_j_mid / F_minus[j_mid - 1]) < 1.0e-6
+            ):
+                j_mid -= 1
+                F_minus_j_mid = F_minus[j_mid]
+            for j in range(j_plus, j_mid, -1):
+                F_plus[j - 1] = -(
+                    Xf(j, j2, j3, m1) * F_plus[j + 1]
+                    + Yf(j, j2, j3, m2, m3) * F_plus[j]
+                ) / Zf(j, j2, j3, m1)
+                if abs(F_plus[j - 1]) > 1.0:
+                    F_plus[j - 1 : j_max + 1] /= scale_factor
+            F_plus_j_mid = F_plus[j_mid]
+            if j_mid == j_max:
+                f[j_min : j_max + 1] = F_minus[j_min : j_max + 1]
+            elif j_mid == j_min:
+                f[j_min : j_max + 1] = F_plus[j_min : j_max + 1]
+            else:
+                f[j_min : j_mid + 1] = (
+                    F_minus[j_min : j_mid + 1] * F_plus_j_mid / F_minus_j_mid
+                )
+                f[j_mid + 1 : j_max + 1] = F_plus[j_mid + 1 : j_max + 1]
+
+        elif not undefined_min and undefined_max:
+            # Iterate upwards only
+            for j in range(j_minus, j_plus):
+                F_minus[j + 1] = -(
+                    Zf(j, j2, j3, m1) * F_minus[j - 1]
+                    + Yf(j, j2, j3, m2, m3) * F_minus[j]
+                ) / Xf(j, j2, j3, m1)
+                if abs(F_minus[j + 1]) > 1:
+                    F_minus[j_min : j + 1 + 1] /= scale_factor
+            f[j_min : j_max + 1] = F_minus[j_min : j_max + 1]
+
+        elif undefined_min and not undefined_max:
+            # Iterate downwards only
+            for j in range(j_plus, j_min, -1):
+                F_plus[j - 1] = -(
+                    Xf(j, j2, j3, m1) * F_plus[j + 1]
+                    + Yf(j, j2, j3, m2, m3) * F_plus[j]
+                ) / Zf(j, j2, j3, m1)
+                if abs(F_plus[j - 1]) > 1:
+                    F_plus[j - 1 : j_max + 1] /= scale_factor
+            f[j_min : j_max + 1] = F_plus[j_min : j_max + 1]
+
+        #############
+        # Finish up #
+        #############
+        normalize(f, j_min, j_max)
+        determine_signs(f, j_min, j_max, j2, j3, m2, m3)
+        return f
+
+
+def Wigner3j(j_1, j_2, j_3, m_1, m_2, m_3):
+    """Calculate the Wigner 3-j symbol
+
+    NOTE: If you are calculating more than one value, you probably want to use the
+    Wigner3jCalculator object.  This function uses that object inefficiently because, in
+    computing one particular value, that object uses recurrence relations to compute
+    numerous nearby values that you will probably need to compute anyway.
+
+    The result is what is normally represented as
+
+        ⎛j₁  j₂  j₃⎞
+        ⎝m₁  m₂  m₃⎠
+
+    The inputs must be integers.  (Half integer arguments are sacrificed so that we can
+    use numba.)  Nonzero return quantities only occur when the `j`s obey the triangle
+    inequality (any two must add up to be as big as or bigger than the third).
+
+    Examples
+    ========
+
+    >>> from spherical import Wigner3j
+    >>> Wigner3j(2, 6, 4, 0, 0, 0)
+    0.186989398002
+    >>> Wigner3j(2, 6, 4, 0, 0, 1)
+    0
+
+    """
+    if m_1 + m_2 + m_3 != 0:
+        return 0.0
+    if abs(m_1) > j_1 or abs(m_2) > j_2 or abs(m_3) > j_3:
+        return 0.0
+    # Permute cyclically to ensure that j_1 is the largest
+    if j_1 == max(j_1, j_2, j_3):
+        pass
+    elif j_2 == max(j_1, j_2, j_3):
+        j_1, j_2, j_3 = j_2, j_3, j_1
+        m_1, m_2, m_3 = m_2, m_3, m_1
+    else:  # j_3 == max(j_1, j_2, j_3)
+        j_1, j_2, j_3 = j_3, j_1, j_2
+        m_1, m_2, m_3 = m_3, m_1, m_2
+    if j_1 > j_2 + j_3:
+        return 0.0
+    calculator = Wigner3jCalculator(j_2, j_3)
+    w3j = calculator.calculate(j_2, j_3, m_2, m_3)
+    return w3j[j_1]
+
+
+def clebsch_gordan(j_1, m_1, j_2, m_2, j_3, m_3):
+    """Calculate the Clebsch-Gordan coefficient <j1 m1 j2 m2 | j3 m3>
+
+    NOTE: If you are calculating more than one value, you probably want to use the
+    Wigner3jCalculator object.  This function uses that object inefficiently because, in
+    computing one particular value, that object uses recurrence relations to compute
+    numerous nearby values that you will probably need to compute anyway.
+
+    """
+    return (
+        (-1.0) ** (j_1 - j_2 + m_3)
+        * math.sqrt(2 * j_3 + 1)
+        * Wigner3j(j_1, j_2, j_3, m_1, m_2, -m_3)
+    )

--- a/src/jaxoplanet/experimental/starry/ylm.py
+++ b/src/jaxoplanet/experimental/starry/ylm.py
@@ -50,6 +50,15 @@ class Ylm(eqx.Module):
     def todense(self) -> Array:
         return self.tosparse().todense()
 
+    @classmethod
+    def from_dense(cls, y: Array) -> "Ylm":
+        data = {}
+        for i, ylm in enumerate(y):
+            ell = int(np.floor(np.sqrt(i)))
+            m = i - ell * (ell + 1)
+            data[(ell, m)] = ylm
+        return cls(data)
+
     def __mul__(self, other: Any) -> "Ylm":
         if isinstance(other, Ylm):
             return _mul(self, other)
@@ -59,6 +68,10 @@ class Ylm(eqx.Module):
     def __rmul__(self, other: Any) -> "Ylm":
         assert not isinstance(other, Ylm)
         return jax.tree_util.tree_map(lambda x: other * x, self)
+
+    def __getitem__(self, key) -> Array:
+        assert isinstance(key, tuple)
+        return self.todense()[self.index(*key)]
 
 
 def _mul(f: Ylm, g: Ylm) -> Ylm:

--- a/src/jaxoplanet/experimental/starry/ylm.py
+++ b/src/jaxoplanet/experimental/starry/ylm.py
@@ -1,17 +1,20 @@
+import math
+from collections import defaultdict
 from collections.abc import Mapping
 from typing import Any
 
 import equinox as eqx
+import jax
 import jax.numpy as jnp
 import numpy as np
 from jax.experimental.sparse import BCOO
 
+from jaxoplanet.experimental.starry.wigner3j import Wigner3jCalculator
 from jaxoplanet.types import Array
 
 
 class Ylm(eqx.Module):
-    coeffs: Array
-    indices: list[tuple[int, int]] = eqx.field(static=True)
+    data: dict[tuple[int, int], Array]
     ell_max: int = eqx.field(static=True)
     diagonal: bool = eqx.field(static=True)
 
@@ -20,15 +23,17 @@ class Ylm(eqx.Module):
         # starry, that is always forced to be 1, and all the entries will be
         # normalized if an explicit value is provided. Do we want to enforce
         # that here too?
-        indices, coeffs = zip(*dict(data).items())
-        self.coeffs = jnp.asarray(coeffs)
-        self.indices = indices
-        self.ell_max = max(ell for ell, _ in indices)
-        self.diagonal = all(m == 0 for _, m in indices)
+        self.data = dict(data)
+        self.ell_max = max(ell for ell, _ in data.keys())
+        self.diagonal = all(m == 0 for _, m in data.keys())
 
     @property
     def degree(self):
         return self.ell_max**2 + 2 * self.ell_max + 1
+
+    @property
+    def indices(self):
+        return self.data.keys()
 
     def index(self, ell: Array, m: Array) -> Array:
         if np.any(np.abs(m) > ell):
@@ -38,19 +43,64 @@ class Ylm(eqx.Module):
         return ell * (ell + 1) + m
 
     def tosparse(self) -> BCOO:
-        idx = np.array([self.index(ell, m) for ell, m in self.indices])[:, None]
-        return BCOO((self.coeffs, idx), shape=(self.degree,))
+        indices, values = zip(*self.data.items())
+        idx = np.array([self.index(ell, m) for ell, m in indices])[:, None]
+        return BCOO((jnp.asarray(values), idx), shape=(self.degree,))
 
     def todense(self) -> Array:
         return self.tosparse().todense()
 
     def __mul__(self, other: Any) -> "Ylm":
         if isinstance(other, Ylm):
-            # TODO(dfm): Implement product function!
-            raise NotImplementedError
+            return _mul(self, other)
         else:
-            return eqx.tree_at(lambda t: t.coeffs, self, self.coeffs * other)
+            return jax.tree_util.tree_map(lambda x: x * other, self)
 
     def __rmul__(self, other: Any) -> "Ylm":
         assert not isinstance(other, Ylm)
-        return eqx.tree_at(lambda t: t.coeffs, self, other * self.coeffs)
+        return jax.tree_util.tree_map(lambda x: other * x, self)
+
+
+def _mul(f: Ylm, g: Ylm) -> Ylm:
+    """
+    Based closely on the implementation from the MIT-licensed spherical package:
+
+    https://github.com/moble/spherical/blob/0aa81c309cac70b90f8dfb743ce35d2cc9ae6dee/spherical/multiplication.py
+    """
+    ellmax_f = f.ell_max
+    ellmax_g = g.ell_max
+    ellmax_fg = ellmax_f + ellmax_g
+    fg = defaultdict(lambda *_: 0.0)
+    m_calculator = Wigner3jCalculator(ellmax_f, ellmax_g)
+    for ell1 in range(ellmax_f + 1):
+        sqrt1 = math.sqrt((2 * ell1 + 1) / (4 * math.pi))
+        for m1 in range(-ell1, ell1 + 1):
+            idx1 = (ell1, m1)
+            if idx1 not in f.data:
+                continue
+            sum1 = sqrt1 * f.data[idx1]
+            for ell2 in range(ellmax_g + 1):
+                sqrt2 = math.sqrt(2 * ell2 + 1)
+                # w3j_s = s_calculator.calculate(ell1, ell2, s_f, s_g)
+                for m2 in range(-ell2, ell2 + 1):
+                    w3j_m = m_calculator.calculate(ell1, ell2, m1, m2)
+                    idx2 = (ell2, m2)
+                    if idx2 not in g.data:
+                        continue
+                    sum2 = sqrt2 * g.data[idx2]
+                    m3 = m1 + m2
+                    for ell3 in range(
+                        max(abs(m3), abs(ell1 - ell2)), min(ell1 + ell2, ellmax_fg) + 1
+                    ):
+                        # Could loop over same (ell3, m3) more than once, so add all
+                        # contributions together
+                        fg[(ell3, m3)] += (
+                            (
+                                math.pow(-1, ell1 + ell2 + ell3 + m3)
+                                * math.sqrt(2 * ell3 + 1)
+                                * w3j_m[ell3]  # Wigner3j(ell1, ell2, ell3, m1, m2, -m3)
+                            )
+                            * sum1
+                            * sum2
+                        )
+    return Ylm(fg)

--- a/src/jaxoplanet/experimental/starry/ylm.py
+++ b/src/jaxoplanet/experimental/starry/ylm.py
@@ -83,10 +83,10 @@ def _mul(f: Ylm, g: Ylm) -> Ylm:
                 sqrt2 = math.sqrt(2 * ell2 + 1)
                 # w3j_s = s_calculator.calculate(ell1, ell2, s_f, s_g)
                 for m2 in range(-ell2, ell2 + 1):
-                    w3j_m = m_calculator.calculate(ell1, ell2, m1, m2)
                     idx2 = (ell2, m2)
                     if idx2 not in g.data:
                         continue
+                    w3j_m = m_calculator.calculate(ell1, ell2, m1, m2)
                     sum2 = sqrt2 * g.data[idx2]
                     m3 = m1 + m2
                     for ell3 in range(

--- a/src/jaxoplanet/experimental/starry/ylm.py
+++ b/src/jaxoplanet/experimental/starry/ylm.py
@@ -31,6 +31,10 @@ class Ylm(eqx.Module):
         return self.ell_max**2 + 2 * self.ell_max + 1
 
     def index(self, ell: Array, m: Array) -> Array:
+        if np.any(np.abs(m) > ell):
+            raise ValueError(
+                "All spherical harmonic orders 'm' must be in the range [-ell, ell]"
+            )
         return ell * (ell + 1) + m
 
     def tosparse(self) -> BCOO:

--- a/src/jaxoplanet/experimental/starry/ylm.py
+++ b/src/jaxoplanet/experimental/starry/ylm.py
@@ -1,0 +1,52 @@
+from collections.abc import Mapping
+from typing import Any
+
+import equinox as eqx
+import jax.numpy as jnp
+import numpy as np
+from jax.experimental.sparse import BCOO
+
+from jaxoplanet.types import Array
+
+
+class Ylm(eqx.Module):
+    coeffs: Array
+    indices: list[tuple[int, int]] = eqx.field(static=True)
+    ell_max: int = eqx.field(static=True)
+    diagonal: bool = eqx.field(static=True)
+
+    def __init__(self, data: Mapping[tuple[int, int], Array]):
+        # TODO(dfm): Think about how we want to handle the case of (0, 0). In
+        # starry, that is always forced to be 1, and all the entries will be
+        # normalized if an explicit value is provided. Do we want to enforce
+        # that here too?
+        indices, coeffs = zip(*dict(data).items())
+        self.coeffs = jnp.asarray(coeffs)
+        self.indices = indices
+        self.ell_max = max(ell for ell, _ in indices)
+        self.diagonal = all(m == 0 for _, m in indices)
+
+    @property
+    def degree(self):
+        return self.ell_max**2 + 2 * self.ell_max + 1
+
+    def index(self, ell: Array, m: Array) -> Array:
+        return ell * (ell + 1) + m
+
+    def tosparse(self) -> BCOO:
+        idx = np.array([self.index(ell, m) for ell, m in self.indices])[:, None]
+        return BCOO((self.coeffs, idx), shape=(self.degree,))
+
+    def todense(self) -> Array:
+        return self.tosparse().todense()
+
+    def __mul__(self, other: Any) -> "Ylm":
+        if isinstance(other, Ylm):
+            # TODO(dfm): Implement product function!
+            raise NotImplementedError
+        else:
+            return eqx.tree_at(lambda t: t.coeffs, self, self.coeffs * other)
+
+    def __rmul__(self, other: Any) -> "Ylm":
+        assert not isinstance(other, Ylm)
+        return eqx.tree_at(lambda t: t.coeffs, self, other * self.coeffs)

--- a/tests/experimental/starry/ylm_test.py
+++ b/tests/experimental/starry/ylm_test.py
@@ -1,0 +1,31 @@
+import pytest
+
+from jaxoplanet.experimental.starry.ylm import Ylm
+from jaxoplanet.test_utils import assert_allclose
+
+
+@pytest.mark.parametrize("data", [{(5, 0): 5.0, (3, -1): 1.5}])
+def test_starry_ylm_compare(data):
+    starry = pytest.importorskip("starry")
+    theano = pytest.importorskip("theano")
+    theano.config.gcc__cxxflags += " -fexceptions"
+
+    # >>> import starry
+    # m = starry.Map(5)
+    # m[:,>>> m = starry.Map(5)
+    # Pre-computing some matrices... Done.
+    # >>> m[5, 0] = 5.0
+    # >>> m[3, -1] = 1.5
+    # >>> m._y
+    # AdvancedIncSubtensor1{no_inplace,set}.0
+    # >>> m._y.eval()
+
+    data = dict(data)
+    data.update({(0, 0): 1.0})
+    ylm = Ylm(data)
+    starry_map = starry.Map(ylm.ell_max)
+    for (ell, m), c in data.items():
+        if (ell, m) == (0, 0):
+            continue
+        starry_map[ell, m] = c
+    assert_allclose(ylm.todense(), starry_map._y.eval())

--- a/tests/experimental/starry/ylm_test.py
+++ b/tests/experimental/starry/ylm_test.py
@@ -10,16 +10,6 @@ def test_starry_ylm_compare(data):
     theano = pytest.importorskip("theano")
     theano.config.gcc__cxxflags += " -fexceptions"
 
-    # >>> import starry
-    # m = starry.Map(5)
-    # m[:,>>> m = starry.Map(5)
-    # Pre-computing some matrices... Done.
-    # >>> m[5, 0] = 5.0
-    # >>> m[3, -1] = 1.5
-    # >>> m._y
-    # AdvancedIncSubtensor1{no_inplace,set}.0
-    # >>> m._y.eval()
-
     data = dict(data)
     data.update({(0, 0): 1.0})
     ylm = Ylm(data)


### PR DESCRIPTION
Based on conversations this morning, here's a sketch of an interface for building spherical harmonic maps in a jax-friendly way. The basic interface is something like:

```python
ylm_map = Ylm(
  {
    (0, 0): 1.0,
    (1, 0): 1.5,
    (5, -2): 0.5,
  }
)
```

which would be equivalent to

```python
starry_map = starry.Map(5)
starry_map[1, 0] = 1.5
starry_map[5, -2] = 0.5
```

Note that there is currently a difference in how `(0, 0)` is treated (I think that our best bet would be to match the starry behavior).

The main thing that I'd want to add before merging would be to implement the product operator. I don't _think_ there's any reason to use the "filter" interface from the original starry implementation vs just updating the map. Therefore, limb darkening would be implemented as the product of two spherical harmonic maps.

cc @lgrcia @benjaminpope @shashankdholakia