### PR TITLE
Implementing render functions

### DIFF
--- a/src/jaxoplanet/experimental/starry/render.py
+++ b/src/jaxoplanet/experimental/starry/render.py
@@ -1,0 +1,42 @@
+import jax.numpy as jnp
+
+from jaxoplanet.experimental.starry.basis import A1, poly_basis
+from jaxoplanet.experimental.starry.wigner import dot_rotation_matrix
+
+
+def ortho_grid(res):
+    x, y = jnp.meshgrid(jnp.linspace(-1, 1, res), jnp.linspace(-1, 1, res))
+    z = jnp.sqrt(1 - x**2 - y**2)
+    y = y + 0.0 * z  # propagate nans
+    x = jnp.ravel(x)[None, :]
+    y = jnp.ravel(y)[None, :]
+    z = jnp.ravel(z)[None, :]
+    lat = 0.5 * jnp.pi - jnp.arccos(y)
+    lon = jnp.arctan2(x, z)
+    return (lat, lon), (x, y, z)
+
+
+def left_project(deg, M, theta, inc, obl):
+    # Note that here we are using the fact that R . M = (M^T . R^T)^T
+    MT = jnp.transpose(M)
+
+    # Rotate to the polar frame
+    MT = dot_rotation_matrix(deg, 1.0, 0.0, 0.0, -0.5 * jnp.pi)(MT)
+    MT = dot_rotation_matrix(deg, None, None, 1.0, -theta)(MT)
+
+    # Rotate to the sky frame
+    MT = dot_rotation_matrix(deg, 1.0, 0.0, 0.0, 0.5 * jnp.pi)(MT)
+    MT = dot_rotation_matrix(deg, None, None, 1.0, -obl)(MT)
+    MT = dot_rotation_matrix(
+        deg, -jnp.cos(obl), -jnp.sin(obl), 0.0, 0.5 * jnp.pi - inc
+    )(MT)
+
+    return M.T
+
+
+def render(deg, res, theta, inc, obl, y):
+    _, xyz = ortho_grid(res)
+    pT = poly_basis(deg)(*xyz)
+    Ry = left_project(deg, y, theta, inc, obl)
+    A1Ry = A1(deg) @ Ry
+    return jnp.reshape(pT @ A1Ry, (res, res))

--- a/src/jaxoplanet/experimental/starry/render.py
+++ b/src/jaxoplanet/experimental/starry/render.py
@@ -31,7 +31,7 @@ def left_project(deg, M, theta, inc, obl):
         deg, -jnp.cos(obl), -jnp.sin(obl), 0.0, 0.5 * jnp.pi - inc
     )(MT)
 
-    return M.T
+    return MT
 
 
 def render(deg, res, theta, inc, obl, y):


### PR DESCRIPTION
After this PR, the following code:

```python
import matplotlib.pyplot as plt
import jax.numpy as jnp
from jaxoplanet.experimental.starry.render import render

y = jnp.array(
    [1.00,  0.22,  0.19,  0.11,  0.11,  0.07,  -0.11, 0.00,  -0.05,
     0.12,  0.16,  -0.05, 0.06,  0.12,  0.05,  -0.10, 0.04,  -0.02,
     0.01,  0.10,  0.08,  0.15,  0.13,  -0.11, -0.07, -0.14, 0.06,
     -0.19, -0.02, 0.07,  -0.02, 0.07,  -0.01, -0.07, 0.04,  0.00]
)
img = render(5, 500, 0.0, 0.0, 0.0, y)
plt.imshow(img, origin="lower")
plt.savefig("render.png", dpi=100, bbox_inches="tight");
```

produces this image:

![render](https://github.com/exoplanet-dev/jaxoplanet/assets/350282/dd49f83b-4efb-4d94-92d7-f118de5179d8)

which we can compare to [the starry docs](https://starry.readthedocs.io/en/latest/notebooks/Basics/): 

![](https://starry.readthedocs.io/en/latest/_images/notebooks_Basics_9_0.png)