### PR TITLE
Upload docs build logs when the build fails

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -52,6 +52,30 @@ jobs:
           python -m nox --non-interactive --error-on-missing-interpreter \
             --session "${{matrix.session}}-${{matrix.python-version}}"
 
+  docs-build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v5
+        name: Install Python
+        with:
+          python-version: "3.10"
+      - name: Install dependencies
+        run: |
+          python -m pip install -U pip
+          python -m pip install -U nox
+      - name: "Build: docs"
+        run: |
+          python -m nox --non-interactive --session docs
+      - name: "Upload logs on failure"
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: docs
+          path: docs/_build
+
   build:
     runs-on: ubuntu-latest
     steps:
@@ -72,6 +96,7 @@ jobs:
         run: python -m twine check --strict dist/*
       - uses: actions/upload-artifact@v4
         with:
+          name: dist
           path: dist/*
 
   publish:
@@ -86,6 +111,6 @@ jobs:
     steps:
       - uses: actions/download-artifact@v4
         with:
-          name: artifact
+          name: dist
           path: dist
       - uses: pypa/gh-action-pypi-publish@v1.8.11


### PR DESCRIPTION
In some of the PRs from the docathon (#107, #108, #109, #110, and #111 lol) we're getting build errors on the Read the Docs that are hard to debug. This PR adds a workflow on GitHub Actions that should build the docs in nearly the same environment as on RTDs, and then upload the full build output if it fails. This should make it easier to track down the issues.