### PR TITLE
Updating ruff configuration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,8 @@ line-length = 88
 [tool.ruff]
 line-length = 89
 target-version = "py39"
+
+[tool.ruff.lint]
 select = ["F", "I", "E", "W", "YTT", "B", "Q", "PLE", "PLR", "PLW", "UP"]
 ignore = [
     "B023",    # Allow using global variables in lambdas
@@ -65,8 +67,8 @@ ignore = [
     "PLR0915", # Allow many statements
     "PLR2004", # Allow magic numbers in comparisons
 ]
-exclude = []
+# exclude = []
 
-[tool.ruff.isort]
+[tool.ruff.lint.isort]
 known-first-party = ["jaxoplanet"]
 combine-as-imports = true


### PR DESCRIPTION
The previous setup was emitting the following warning:

```
warning: The top-level linter settings are deprecated in favour of their
counterparts in the `lint` section. Please update the following options
in `pyproject.toml`:
  - 'ignore' -> 'lint.ignore'
  - 'select' -> 'lint.select'
  - 'isort' -> 'lint.isort'
```