### PR TITLE
Truncate `_body_stack` in Keplerian `System`'s `__repr__`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ build
 dist
 poetry.lock
 .*_cache
+.jupyter

--- a/tests/orbits/keplerian_test.py
+++ b/tests/orbits/keplerian_test.py
@@ -166,7 +166,9 @@ def test_keplerian_body_positions_small_star(time):
 
 def test_keplerian_system_stack_construction():
     sys = keplerian.System().add_body(period=0.1).add_body(period=0.2)
-    assert_quantity_allclose(sys._body_stack.period, jnp.array([0.1, 0.2]) * ureg.day)
+    assert_quantity_allclose(
+        sys._body_stack.stack.period, jnp.array([0.1, 0.2]) * ureg.day
+    )
 
     sys = (
         keplerian.System()
@@ -186,7 +188,7 @@ def test_keplerian_system_radial_velocity():
     assert sys1._body_stack is not None
     assert sys2._body_stack is None
     with pytest.raises(ValueError):
-        sys1._body_stack.radial_velocity(0.0)
+        sys1._body_stack.stack.radial_velocity(0.0)
 
     for t in [0.0, jnp.linspace(0, 1, 5)]:
         assert_quantity_allclose(


### PR DESCRIPTION
The `_body_stack` is an implementation detail that we don't really need most users to think about. Since we're now encourage users to print these objects to inspect them, I wanted to de-emphasize this field. With this in mind, this PR updates the `__repr__` in `System` to "truncate" this field. This means that we now see something like:

```python
>>> System().add_body(period=1)
System(
  central=Central(
    mass=<Quantity(1.0, 'M_sun')>,
    radius=<Quantity(1.0, 'R_sun')>,
    density=<Quantity(0.238732415, 'M_sun / R_sun ** 3')>
  ),
  bodies=(
    Body(
      central=Central(
        mass=<Quantity(1.0, 'M_sun')>,
        radius=<Quantity(1.0, 'R_sun')>,
        density=<Quantity(0.238732415, 'M_sun / R_sun ** 3')>
      ),
      time_ref=<Quantity(-0.25, 'day')>,
      time_transit=<Quantity(0, 'day')>,
      period=<Quantity(1, 'day')>,
      semimajor=<Quantity(4.208278179168701, 'R_sun')>,
      sin_inclination=<Quantity(1, 'dimensionless')>,
      cos_inclination=<Quantity(0, 'dimensionless')>,
      impact_param=<Quantity(0, 'dimensionless')>,
      mass=None,
      radius=None,
      eccentricity=None,
      sin_omega_peri=None,
      cos_omega_peri=None,
      sin_asc_node=None,
      cos_asc_node=None,
      radial_velocity_semiamplitude=None,
      parallax=None
    ),
  ),
  _body_stack=BodyStack(...)
)
```

which (while verbose) is better than before:

```python
>>> System().add_body(period=1)
System(
  central=Central(
    mass=<Quantity(1.0, 'M_sun')>,
    radius=<Quantity(1.0, 'R_sun')>,
    density=<Quantity(0.238732415, 'M_sun / R_sun ** 3')>
  ),
  bodies=(
    Body(
      central=Central(
        mass=<Quantity(1.0, 'M_sun')>,
        radius=<Quantity(1.0, 'R_sun')>,
        density=<Quantity(0.238732415, 'M_sun / R_sun ** 3')>
      ),
      time_ref=<Quantity(-0.25, 'day')>,
      time_transit=<Quantity(0, 'day')>,
      period=<Quantity(1, 'day')>,
      semimajor=<Quantity(4.208278179168701, 'R_sun')>,
      sin_inclination=<Quantity(1, 'dimensionless')>,
      cos_inclination=<Quantity(0, 'dimensionless')>,
      impact_param=<Quantity(0, 'dimensionless')>,
      mass=None,
      radius=None,
      eccentricity=None,
      sin_omega_peri=None,
      cos_omega_peri=None,
      sin_asc_node=None,
      cos_asc_node=None,
      radial_velocity_semiamplitude=None,
      parallax=None
    ),
  ),
  _body_stack=Body(
    central=Central(
      mass=<Quantity([1.], 'M_sun')>,
      radius=<Quantity([1.], 'R_sun')>,
      density=<Quantity([0.23873241], 'M_sun / R_sun ** 3')>
    ),
    time_ref=<Quantity([-0.25], 'day')>,
    time_transit=<Quantity([0], 'day')>,
    period=<Quantity([1], 'day')>,
    semimajor=<Quantity([4.208278], 'R_sun')>,
    sin_inclination=<Quantity([1], 'dimensionless')>,
    cos_inclination=<Quantity([0], 'dimensionless')>,
    impact_param=<Quantity([0], 'dimensionless')>,
    mass=None,
    radius=None,
    eccentricity=None,
    sin_omega_peri=None,
    cos_omega_peri=None,
    sin_asc_node=None,
    cos_asc_node=None,
    radial_velocity_semiamplitude=None,
    parallax=None
  )
)
```