### PR TITLE
Drafting faster transit fitting tutorial

### DIFF
--- a/docs/tutorials/transit.ipynb
+++ b/docs/tutorials/transit.ipynb
@@ -40,7 +40,7 @@
     "import copy\n",
     "\n",
     "numpyro.set_host_device_count(\n",
-    "    4\n",
+    "    2\n",
     ")  # For multi-core parallelism (useful when running multiple MCMC chains in parallel)\n",
     "numpyro.set_platform(\"cpu\")  # For CPU (use \"gpu\" for GPU)\n",
     "jax.config.update(\n",
@@ -115,22 +115,22 @@
    "outputs": [],
    "source": [
     "# Simulate some data with Gaussian noise\n",
-    "np.random.seed(21)\n",
-    "PERIOD = np.random.uniform(5, 20, 1)[0]  # day\n",
-    "T0 = PERIOD * np.random.rand(1)[0]  # day\n",
+    "random = np.random.default_rng(42)\n",
+    "PERIOD = random.uniform(2, 5)  # day\n",
+    "T0 = PERIOD * random.uniform()  # day\n",
     "DURATION = 0.5  # day\n",
-    "B = 0.1  # impact parameter\n",
+    "B = 0.5  # impact parameter\n",
     "ROR = 0.08  # planet radius / star radius\n",
     "U = np.array([0.1, 0.06])  # limb darkening coefficients\n",
     "yerr = 5e-4  # flux uncertainty\n",
-    "t = np.arange(0, 40, 0.02)  # day\n",
+    "t = np.arange(0, 17, 0.02)  # day\n",
     "\n",
     "\n",
     "orbit = TransitOrbit(\n",
     "    period=PERIOD, duration=DURATION, time_transit=T0, impact_param=B, radius=ROR\n",
     ")\n",
     "y_true = LimbDarkLightCurve(U).light_curve(orbit, t)\n",
-    "y = y_true + yerr * np.random.randn(len(t))\n",
+    "y = y_true + yerr * random.normal(size=len(t))\n",
     "\n",
     "# Let's see what the light curve looks like\n",
     "plt.figure(dpi=150)\n",
@@ -179,6 +179,7 @@
     "    # r = numpyro.deterministic(\"r\", jnp.exp(logR))\n",
     "\n",
     "    # The impact parameter\n",
+    "    # b = numpyro.sample(\"b\", numpyro.distributions.Uniform(0, 1.0))\n",
     "    _b = numpyro.sample(\"_b\", numpyro.distributions.Uniform(0, 1.0))\n",
     "    b = numpyro.deterministic(\"b\", _b * (1 + r))\n",
     "\n",
@@ -299,7 +300,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "opt_params"
+    "for k, v in opt_params.items():\n",
+    "    if k in [\"light_curve\", \"obs\", \"_b\"]:\n",
+    "        continue\n",
+    "    print(f\"{k}: {v}\")"
    ]
   },
   {
@@ -345,7 +349,7 @@
     "\n",
     "This cell takes about 4 minutes to run on my laptop. Dont' worry if you don't see any progress in the first minute or two, it \n",
     "\n",
-    "Below, we're setting the ``regularize_mass_matrix`` keyword to ``False``. This is because we realized that the default of setting it to ``True`` causes the sampling to be slower (roughly 6-7 times slower). We're investigating why but it seems (at least for this case) the posteriors are pretty much the same whether you regularizae the mass matrix or not. As a side note, not regularizing the mass matrix means we're essentially trading robustness of sampling for speed and may get some divergences. We'll look at these divergences later."
+    "Below, we're setting the ``regularize_mass_matrix`` keyword to ``False``. This is because we realized that the default of setting it to ``True`` causes the sampling to be slower (roughly 6-7 times slower). We're investigating why but it seems (at least for this case) the posteriors are pretty much the same whether you regularize the mass matrix or not. As a side note, not regularizing the mass matrix means we're essentially trading robustness of sampling for speed and may get some divergences. We'll look at these divergences later."
    ]
   },
   {
@@ -361,9 +365,9 @@
     "        regularize_mass_matrix=False,\n",
     "        init_strategy=numpyro.infer.init_to_value(values=opt_params),\n",
     "    ),\n",
-    "    num_warmup=500,\n",
+    "    num_warmup=1000,\n",
     "    num_samples=1000,\n",
-    "    num_chains=4,\n",
+    "    num_chains=2,\n",
     "    progress_bar=True,\n",
     ")\n",
     "\n",
@@ -630,7 +634,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.1"
+   "version": "3.10.10"
   }
  },
  "nbformat": 4,

--- a/docs/tutorials/transit.ipynb
+++ b/docs/tutorials/transit.ipynb
@@ -345,11 +345,11 @@
    "metadata": {},
    "source": [
     "## Sampling\n",
-    "Let's sample from the posterior defined by this model and data. We'll use the No-U-Turn Sampler (NUTS) algorithm, which is a variant of the Hamiltonian Monte Carlo (HMC) algorithm without the need to hand-tune some of the sampling parameters.\n",
+    "Let's sample from the posterior defined by this model and data. We'll use the No-U-Turn Sampler (NUTS) algorithm, which is a variant of the Hamiltonian Monte Carlo (HMC) algorithm that automatically tunes some of the sampling parameters.\n",
     "\n",
-    "This cell takes about 4 minutes to run on my laptop. Dont' worry if you don't see any progress in the first minute or two, it \n",
+    "This cell takes about a minute to run on my laptop. Don't worry if it doesn't seem like anything is happening for a while at the beginning; compiling the code and running the first 100-200 iterations are the most computationally demanding and the subsequent sampling runs much faster!\n",
     "\n",
-    "Below, we're setting the ``regularize_mass_matrix`` keyword to ``False``. This is because we realized that the default of setting it to ``True`` causes the sampling to be slower (roughly 6-7 times slower). We're investigating why but it seems (at least for this case) the posteriors are pretty much the same whether you regularize the mass matrix or not. As a side note, not regularizing the mass matrix means we're essentially trading robustness of sampling for speed and may get some divergences. We'll look at these divergences later."
+    "Below, we're setting the ``regularize_mass_matrix`` keyword to ``False``. This is because we realized that the default of setting it to ``True`` causes the sampling to be slower (roughly 4 times slower). We're investigating why but it seems (at least for this case) the posteriors are pretty much the same whether you regularize the mass matrix or not."
    ]
   },
   {
@@ -366,7 +366,7 @@
     "        init_strategy=numpyro.infer.init_to_value(values=opt_params),\n",
     "    ),\n",
     "    num_warmup=1000,\n",
-    "    num_samples=1000,\n",
+    "    num_samples=2000,\n",
     "    num_chains=2,\n",
     "    progress_bar=True,\n",
     ")\n",
@@ -381,7 +381,7 @@
    "source": [
     "## Checking our posterior samples\n",
     "\n",
-    "We should check the convergence of our sampler. Determining whether a sampler has converged is not trivial and there is a lot of literature on the subject. In our case, we'll attempt to check for convergence by looking at the the Gelman-Rubin $\\hat{R}$ statistic and the bulk effective sample size (ESS) of each parameter. \n",
+    "We should check the convergence of our sampler. Determining whether a sampler has converged is not trivial and there is a lot of literature on the subject. Here we'll attempt to check for convergence by looking at the the Gelman-Rubin $\\hat{R}$ statistic and the bulk effective sample size (ESS) of each parameter. \n",
     "\n",
     "- The [$\\hat{R}$ statistic](https://bookdown.org/rdpeng/advstatcomp/monitoring-convergence.html) is a diagnostic of convergence based on the ratio of the variance between chains to the variance within chains. We would like for it to be close to 1.00 for each parameter. \n",
     "- The [ESS](https://mc-stan.org/docs/2_18/reference-manual/effective-sample-size-section.html) is a measure of the number of independent samples in the chains and is inversely correlated with the autocorrelation in a chain. Larger estimates for the ESS are better as they indicate less autocorrelation in the chains.\n",
@@ -405,7 +405,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The ESS (`ess_bulk`) isn't great for some of the parameters, like the impact parameter $b$, but since the $\\hat{R}$ values are good let's just go ahead with these samples."
+    "The ESS (`ess_bulk`) isn't great for some of the parameters, like the duration and the impact parameter $b$, but since the $\\hat{R}$ values are good let's just go ahead with these samples."
    ]
   },
   {
@@ -424,8 +424,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Let's get a different view of the chains by making some trace plots.\n",
-    "The divergences will show up as vertical dashed lines. "
+    "Let's get a different view of the chains by making some trace plots. We can do this using the `plot_trace` function in the `Arviz` package."
    ]
   },
   {
@@ -474,9 +473,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The blue lines indicate the true values. \n",
-    "\n",
-    "The nonlinear correlation between $b$ and $r$ is probably the cause of some of the divergences, but since it's also expected with this parameterization to let's move ahead with it. "
+    "The blue lines indicate the true values. All the true values are within 1-sigma of the marginalized posterior distributions, which is good!"
    ]
   },
   {
@@ -539,83 +536,6 @@
     "ax.legend(fontsize=10, loc=4)\n",
     "ax.set_xlim(-inferred_duration, inferred_duration);"
    ]
-  },
-  {
-   "attachments": {},
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Extra: Divergences\n",
-    "\n",
-    "We briefly discussed [divergences](https://mc-stan.org/docs/2_22/reference-manual/divergent-transitions.html) above. Let's take a closer look at them.\n",
-    "There's a keyword argument in the `corner` package called `divergences` where if we set it to `True` it will show us the divergences in the corner plot. Let's do that now."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "corner.corner(\n",
-    "    inf_data,\n",
-    "    var_names=[\"t0\", \"period\", \"duration\", \"r\", \"b\", \"u\"],\n",
-    "    truths=[T0, PERIOD, DURATION, ROR, B, U[0], U[1]],\n",
-    "    divergences=True,\n",
-    "    divergences_kwargs={\"color\": \"C1\", \"ms\": 10},\n",
-    "    show_titles=True,\n",
-    "    quantiles=[0.16, 0.5, 0.84],\n",
-    "    title_kwargs={\"fontsize\": 12},\n",
-    "    label_kwargs={\"fontsize\": 15},\n",
-    "    title_fmt=\".4f\",\n",
-    ");"
-   ]
-  },
-  {
-   "attachments": {},
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "The orange dots are the divergences. Based on this plot and the trace plot we made before, it looks like the divergences occur when $b$ and $r$ take on \"large\" values. \n",
-    "\n",
-    "Let's take a closer look at it."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Get the indices of the divergences in the sampler\n",
-    "divergent = sampler.get_extra_fields()[\"diverging\"]\n",
-    "\n",
-    "b_good = samples[\"b\"][~divergent]\n",
-    "r_good = samples[\"r\"][~divergent]\n",
-    "b_divergent = samples[\"b\"][divergent]\n",
-    "r_divergent = samples[\"r\"][divergent]"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "fig, ax = plt.subplots(dpi=300)\n",
-    "ax.plot(r_good, b_good, \".k\", ms=1, alpha=0.5, label=\"good\")\n",
-    "ax.plot(r_divergent, b_divergent, \"xr\", ms=10, alpha=1, label=\"divergent\")\n",
-    "ax.set_xlabel(\"radius ratio\")\n",
-    "ax.set_ylabel(\"impact parameter\")\n",
-    "ax.legend(fontsize=10);"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
@@ -634,7 +554,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.10"
+   "version": "3.11.1"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
I'm not sure that we'd want to merge this, but I've sketched out some ideas that make the transit fitting example a bit faster to run. One extra point here is that I'm also not getting any divergences anymore, so we can factor that part out of this tutorial (perhaps we could talk about it in the "intro to numpyro" tutorial?). The only real changes that I made were to:

1. Reduce parallelism (RTDs definitely doesn't allocate 4 cores)
2. Reduce size of dataset smaller and choose somewhat easier parameters

What do you think, @soichiro-hattori?