### PR TITLE
Experimenting with a different interface for exposure time

### DIFF
--- a/docs/tutorials/transit.ipynb
+++ b/docs/tutorials/transit.ipynb
@@ -27,7 +27,7 @@
    "outputs": [],
    "source": [
     "import jaxoplanet\n",
-    "from jaxoplanet.light_curves import LimbDarkLightCurve\n",
+    "from jaxoplanet.light_curves import limb_dark_light_curve\n",
     "from jaxoplanet.orbits import TransitOrbit\n",
     "import numpy as np\n",
     "import matplotlib.pyplot as plt\n",
@@ -84,7 +84,7 @@
     "# Compute a limb-darkened light curve for this orbit\n",
     "t = np.linspace(-0.1, 0.1, 1000)\n",
     "u = [0.1, 0.06]  # Quadratic limb-darkening coefficients\n",
-    "light_curve = LimbDarkLightCurve(u).light_curve(orbit, t)\n",
+    "light_curve = jax.vmap(limb_dark_light_curve(orbit, u))(t)\n",
     "\n",
     "# Plot the light curve\n",
     "plt.figure(dpi=150)\n",
@@ -123,13 +123,13 @@
     "ROR = 0.08  # planet radius / star radius\n",
     "U = np.array([0.1, 0.06])  # limb darkening coefficients\n",
     "yerr = 5e-4  # flux uncertainty\n",
-    "t = np.arange(0, 17, 0.02)  # day\n",
+    "t = np.arange(0, 17, 0.05)  # day\n",
     "\n",
     "\n",
     "orbit = TransitOrbit(\n",
     "    period=PERIOD, duration=DURATION, time_transit=T0, impact_param=B, radius=ROR\n",
     ")\n",
-    "y_true = LimbDarkLightCurve(U).light_curve(orbit, t)\n",
+    "y_true = jax.vmap(limb_dark_light_curve(orbit, U))(t)\n",
     "y = y_true + yerr * random.normal(size=len(t))\n",
     "\n",
     "# Let's see what the light curve looks like\n",
@@ -190,7 +190,7 @@
     "    orbit = TransitOrbit(\n",
     "        period=period, duration=duration, time_transit=t0, impact_param=b, radius=r\n",
     "    )\n",
-    "    y_pred = LimbDarkLightCurve(u).light_curve(orbit, t)\n",
+    "    y_pred = jax.vmap(limb_dark_light_curve(orbit, u))(t)\n",
     "\n",
     "    # Let's track the light curve\n",
     "    numpyro.deterministic(\"light_curve\", y_pred)\n",
@@ -505,7 +505,7 @@
     "    impact_param=inferred_b,\n",
     "    radius=inferred_r,\n",
     ")\n",
-    "y_model = LimbDarkLightCurve(inferred_u).light_curve(orbit, t)\n",
+    "y_model = jax.vmap(limb_dark_light_curve(orbit, inferred_u))(t)\n",
     "\n",
     "fig, ax = plt.subplots(dpi=150)\n",
     "\n",
@@ -536,6 +536,13 @@
     "ax.legend(fontsize=10, loc=4)\n",
     "ax.set_xlim(-inferred_duration, inferred_duration);"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
@@ -554,7 +561,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.1"
+   "version": "3.10.10"
   }
  },
  "nbformat": 4,

--- a/src/jaxoplanet/core/limb_dark.py
+++ b/src/jaxoplanet/core/limb_dark.py
@@ -12,7 +12,7 @@ from jaxoplanet.utils import zero_safe_sqrt
 
 @partial(jax.jit, static_argnames=("order",))
 def light_curve(u: Array, b: Array, r: Array, *, order: int = 10):
-    u = jnp.atleast_1d(u)
+    u = jnp.asarray(u)
     assert u.ndim == 1
     if u.shape[0] == 0:
         g = jnp.full((1,), 1.0 / jnp.pi)
@@ -36,27 +36,25 @@ def solution_vector(l_max: int, order: int = 10) -> Callable[[Array, Array], Arr
         no_occ = jnp.greater_equal(b, 1 + r)
         full_occ = jnp.less_equal(1 + b, r)
         cond = jnp.logical_or(no_occ, full_occ)
-        b_ = jnp.where(cond, jnp.ones_like(b), b)
+        b_: Array = jnp.where(cond, jnp.ones_like(b), b)
 
         b2 = jnp.square(b_)
         r2 = jnp.square(r)
 
         s0, s2 = s0s2(b_, r, b2, r2, area, kappa0, kappa1)
-        s0 = jnp.where(no_occ, jnp.pi, s0)
+        s0: Array = jnp.where(no_occ, jnp.pi, s0)
         s0 = jnp.where(full_occ, jnp.zeros_like(s0), s0)
         s2 = jnp.where(cond, jnp.zeros_like(s2), s2)
 
-        if l_max >= 1:
-            P = p_integral(order, l_max, b_, r, b2, r2, kappa0)
-            P = jnp.where(cond, jnp.zeros_like(P), P)
-
         s = [s0[None]]
         if l_max >= 1:
+            P: Array = p_integral(order, l_max, b_, r, b2, r2, kappa0)
+            P = jnp.where(cond, jnp.zeros_like(P), P)
             s.append(-P[:1] - 2 * (kappa1 - jnp.pi) / 3)
-        if l_max >= 2:
-            s.append(s2[None])
-        if l_max >= 3:
-            s.append(-P[1:])
+            if l_max >= 2:
+                s.append(s2[None])  # type: ignore
+            if l_max >= 3:
+                s.append(-P[1:])
         return jnp.concatenate(s, axis=0)
 
     return impl
@@ -82,7 +80,7 @@ def kappas(b: Array, r: Array) -> tuple[Array, Array, Array]:
     factor = (r - 1) * (r + 1)
     cond = jnp.logical_and(jnp.greater(b, jnp.abs(1 - r)), jnp.less(b, 1 + r))
     b_ = jnp.where(cond, b, jnp.ones_like(b))
-    area = jnp.where(cond, kite_area(r, b_, jnp.ones_like(r)), jnp.zeros_like(r))
+    area: Array = jnp.where(cond, kite_area(r, b_, jnp.ones_like(r)), jnp.zeros_like(r))
     return area, jnp.arctan2(area, b2 + factor), jnp.arctan2(area, b2 - factor)
 
 
@@ -127,7 +125,7 @@ def p_integral(
     # This is a hack for when r -> 0 or b -> 0, so k2 -> inf
     factor = 4 * b * r
     k2_cond = jnp.less(factor, 10 * jnp.finfo(factor.dtype).eps)
-    factor = jnp.where(k2_cond, jnp.ones_like(factor), factor)
+    factor: Array = jnp.where(k2_cond, jnp.ones_like(factor), factor)
     k2 = jnp.maximum(jnp.zeros_like(factor), (1 - r2 - b2 + 2 * b * r) / factor)
 
     roots, weights = roots_legendre(order)

--- a/src/jaxoplanet/exposure_time.py
+++ b/src/jaxoplanet/exposure_time.py
@@ -1,0 +1,67 @@
+from collections.abc import Callable
+from functools import wraps
+from typing import Optional, TypeVar
+
+import jax
+import jax.numpy as jnp
+import jpu.numpy as jnpu
+
+from jaxoplanet.types import Array, Quantity
+
+T = TypeVar("T", Array, Quantity)
+
+
+def integrate_exposure_time(
+    func: Callable[[Quantity], T],
+    exposure_time: Optional[Quantity] = None,
+    order: int = 0,
+    num_samples: int = 7,
+) -> Callable[[Quantity], T]:
+    if exposure_time is None:
+        return func
+
+    if jnpu.ndim(exposure_time) != 0:  # type: ignore
+        raise ValueError(
+            "The exposure time passed to 'integrate_exposure_time' has shape "
+            f"{jnpu.shape(exposure_time)}, but a scalar was expected; "  # type: ignore
+            "To use exposure time integration with different exposures at different "
+            "times, manually 'vmap' or 'vectorize' the function"
+        )
+
+    # Ensure 'num_samples' is an odd number
+    num_samples = int(num_samples)
+    num_samples += 1 - num_samples % 2
+    stencil = jnp.ones(num_samples)
+
+    # Construct exposure time integration stencil
+    if order == 0:
+        dt = jnp.linspace(-0.5, 0.5, 2 * num_samples + 1)[1:-1:2]
+    elif order == 1:
+        dt = jnp.linspace(-0.5, 0.5, num_samples)
+        stencil = 2 * stencil
+        stencil = stencil.at[0].set(1)
+        stencil = stencil.at[-1].set(1)
+    elif order == 2:
+        dt = jnp.linspace(-0.5, 0.5, num_samples)
+        stencil = stencil.at[1:-1:2].set(4)
+        stencil = stencil.at[2:-1:2].set(2)
+    else:
+        raise ValueError(
+            "The parameter 'order' in 'integrate_exposure_time' must be 0, 1, or 2"
+        )
+    dt = dt * exposure_time
+    stencil /= jnp.sum(stencil)
+
+    @wraps(func)
+    def wrapped(time: Quantity) -> T:
+        if jnpu.ndim(time) != 0:  # type: ignore
+            raise ValueError(
+                "The time passed to 'integrate_exposure_time' has shape "
+                f"{jnpu.shape(time)}, but a scalar was expected; "  # type: ignore
+                "To use exposure time integration for an array of times, "
+                "manually 'vmap' or 'vectorize' the function"
+            )
+
+        return jnpu.dot(stencil, jax.vmap(func)(time + dt))  # type: ignore
+
+    return wrapped

--- a/src/jaxoplanet/light_curves.py
+++ b/src/jaxoplanet/light_curves.py
@@ -22,7 +22,7 @@ class LimbDarkLightCurve(eqx.Module):
         else:
             self.u = jnp.array([])
 
-    @units.quantity_input(t=ureg.d, texp=ureg.s)
+    @units.quantity_input(time=ureg.d)
     def __call__(
         self,
         orbit: LightCurveOrbit,
@@ -55,19 +55,12 @@ class LimbDarkLightCurve(eqx.Module):
             )
 
         # Evaluate the coordinates of the transiting body
-        x, y, z = orbit.relative_position(time)
-        b = jnpu.sqrt(x**2 + y**2)  # type: ignore
         r_star = orbit.central_radius
+        x, y, z = orbit.relative_position(time)
+        b = jnpu.sqrt(x**2 + y**2) / r_star  # type: ignore
         r = orbit.radius / r_star
         lc_func = partial(light_curve, self.u, order=order)
-        if orbit.shape == ():
-            b /= r_star
-            lc: Array = lc_func(b.magnitude, r.magnitude)
-        else:
-            b /= r_star[..., None]
-            lc = jnp.vectorize(lc_func, signature="(k),()->(k)")(
-                b.magnitude, r.magnitude
-            )
+        lc: Array = lc_func(b.magnitude, r.magnitude)
         lc = jnp.where(z > 0, lc, 0)
 
         return lc

--- a/src/jaxoplanet/light_curves.py
+++ b/src/jaxoplanet/light_curves.py
@@ -78,10 +78,10 @@ class LimbDarkLightCurve(eqx.Module):
     def light_curve(
         self, orbit: LightCurveOrbit, time: Quantity, *, ld_order: int = 10
     ) -> Array:
-        def _lc_func(time: time) -> _LightCurveFunc[T]:
+        def _lc_func(time: Quantity) -> _LightCurveFunc[T]:
             return self._light_curve(orbit=orbit, time=time, ld_order=ld_order)
 
-        return jax.vmap(_lc_func, in_axes=(0))(time)
+        return jax.vmap(_lc_func, in_axes=(0))(time).T
 
     def _integrated_light_curve(
         self,
@@ -93,11 +93,11 @@ class LimbDarkLightCurve(eqx.Module):
         order: int = 0,
         num_samples: int = 7,
     ) -> _LightCurveFunc[T]:
-        def _partial_lc_func(time):
+        def _lc_func(time: Quantity) -> _LightCurveFunc[T]:
             return self._light_curve(orbit=orbit, time=time, ld_order=ld_order)
 
         _integrated_lc_func = integrate_exposure_time(
-            _partial_lc_func, exposure_time=exposure_time, num_samples=num_samples
+            _lc_func, exposure_time=exposure_time, num_samples=num_samples
         )
         return _integrated_lc_func
 
@@ -119,4 +119,4 @@ class LimbDarkLightCurve(eqx.Module):
             order=order,
             num_samples=num_samples,
         )
-        return jax.vmap(_integrated_lc_func, in_axes=(0))(time)
+        return jax.vmap(_integrated_lc_func, in_axes=(0))(time).T

--- a/src/jaxoplanet/light_curves.py
+++ b/src/jaxoplanet/light_curves.py
@@ -1,5 +1,4 @@
 from functools import partial
-from typing import Optional
 
 import equinox as eqx
 import jax.numpy as jnp
@@ -24,15 +23,12 @@ class LimbDarkLightCurve(eqx.Module):
             self.u = jnp.array([])
 
     @units.quantity_input(t=ureg.d, texp=ureg.s)
-    def light_curve(
+    def __call__(
         self,
         orbit: LightCurveOrbit,
-        t: Quantity,
+        time: Quantity,
         *,
-        texp: Optional[Quantity] = None,
-        oversample: Optional[int] = 7,
-        texp_order: Optional[int] = 0,
-        limbdark_order: Optional[int] = 10,
+        order: int = 10,
     ) -> Array:
         """Get the light curve for an orbit at a set of times
 
@@ -43,70 +39,27 @@ class LimbDarkLightCurve(eqx.Module):
                 The first two coordinate dimensions are treated as being in
                 the plane of the sky and the third coordinate is the line of
                 sight with positive values pointing *away* from the observer.
-                For an example, take a look at :class:`orbits.KeplerianOrbit`.
-            t: The times where the light curve should be evaluated.
-            texp (Optional[Array]): The exposure time of each observation.
-                This can be an Array with the same shape as ``t``.
-                If ``texp`` is provided, ``t`` is assumed to indicate the
-                timestamp at the *middle* of an exposure of length ``texp``.
-            oversample: The number of function evaluations to use when
-                numerically integrating the exposure time. Defaults to 7.
-            texp_order (Optional[int]): The order of the numerical integration
-                scheme. This must be one of the following: ``0`` for a
-                centered Riemann sum (equivalent to the "resampling" procedure
-                suggested by Kipping 2010), ``1`` for the trapezoid rule, or
-                ``2`` for Simpson's rule. Has no effect if ``texp`` is not set.
-                Defaults to 0.
-            limbdark_order (Optional[int]): The quadrature order passed to the
+                For an example, take a look at :class:`orbits.keplerian`.
+            time: The time where the light curve should be evaluated.
+            order: The quadrature order passed to the
                 ``scipy.special.roots_legendre`` function in ``core.limb_dark.py``
                 which implements Gauss-Legendre quadrature. Defaults to 10.
         """
 
-        t = jnpu.atleast_1d(t)
-
-        # Handle exposure time integration
-        if texp is None:
-            tgrid = t
-        else:
-            if (
-                jnp.ndim(texp) == 0
-            ):  # If a scalar is passed, automatically broadcast to the shape of t
-                texp = jnpu.broadcast_to(texp, jnp.shape(t))
-            assert texp.shape == t.shape
-
-            # Ensure oversample is an odd number
-            oversample = int(oversample)
-            oversample += 1 - oversample % 2
-            stencil = jnp.ones(oversample)
-
-            # Construct exposure time integration stencil
-            if texp_order == 0:
-                dt = jnp.linspace(-0.5, 0.5, 2 * oversample + 1)[1:-1:2]
-            elif texp_order == 1:
-                dt = jnp.linspace(-0.5, 0.5, oversample)
-                stencil = 2 * stencil
-                stencil = stencil.at[0].set(1)
-                stencil = stencil.at[-1].set(1)
-            elif texp_order == 2:
-                dt = jnp.linspace(-0.5, 0.5, oversample)
-                stencil = stencil.at[1:-1:2].set(4)
-                stencil = stencil.at[2:-1:2].set(2)
-            else:
-                raise ValueError("order must be 0, 1, or 2")
-            stencil /= jnp.sum(stencil)
-
-            if jnp.ndim(texp) == 0:  # Unnecessary since I check the shapes above?
-                dt = texp * dt
-            else:
-                dt = jnpu.outer(texp, dt)
-            tgrid = (jnpu.reshape(t, newshape=(t.size, 1)) + dt).flatten()
+        if jnpu.ndim(time) != 0:  # type: ignore
+            raise ValueError(
+                "The time passed to 'light_curve' has shape "
+                f"{jnpu.shape(time)}, but a scalar was expected; "  # type: ignore
+                "To use exposure time integration for an array of times, "
+                "manually 'vmap' or 'vectorize' the function"
+            )
 
         # Evaluate the coordinates of the transiting body
-        x, y, z = orbit.relative_position(tgrid)
-        b = jnpu.sqrt(x**2 + y**2)
+        x, y, z = orbit.relative_position(time)
+        b = jnpu.sqrt(x**2 + y**2)  # type: ignore
         r_star = orbit.central_radius
         r = orbit.radius / r_star
-        lc_func = partial(light_curve, self.u, order=limbdark_order)
+        lc_func = partial(light_curve, self.u, order=order)
         if orbit.shape == ():
             b /= r_star
             lc: Array = lc_func(b.magnitude, r.magnitude)
@@ -117,11 +70,9 @@ class LimbDarkLightCurve(eqx.Module):
             )
         lc = jnp.where(z > 0, lc, 0)
 
-        # Integrate over exposure time
-        if texp is not None:
-            if orbit.shape == ():
-                lc = jnp.reshape(lc, newshape=(t.size, oversample))
-            else:
-                lc = jnp.reshape(lc, newshape=(orbit.shape[0], t.size, oversample))
-            lc = jnp.dot(lc, stencil)
         return lc
+
+    def light_curve(
+        self, orbit: LightCurveOrbit, time: Quantity, *, order: int = 10
+    ) -> Array:
+        return self(orbit, time, order=order)

--- a/src/jaxoplanet/light_curves.py
+++ b/src/jaxoplanet/light_curves.py
@@ -1,14 +1,19 @@
 from functools import partial
+from typing import Optional, TypeVar
 
 import equinox as eqx
+import jax
 import jax.numpy as jnp
 import jpu.numpy as jnpu
 
 from jaxoplanet import units
 from jaxoplanet.core.limb_dark import light_curve
+from jaxoplanet.exposure_time import _LightCurveFunc, integrate_exposure_time
 from jaxoplanet.proto import LightCurveOrbit
 from jaxoplanet.types import Array, Quantity
 from jaxoplanet.units import unit_registry as ureg
+
+T = TypeVar("T", Array, Quantity, covariant=True)
 
 
 class LimbDarkLightCurve(eqx.Module):
@@ -28,7 +33,7 @@ class LimbDarkLightCurve(eqx.Module):
         orbit: LightCurveOrbit,
         time: Quantity,
         *,
-        order: int = 10,
+        ld_order: int = 10,
     ) -> Array:
         """Get the light curve for an orbit at a set of times
 
@@ -41,7 +46,7 @@ class LimbDarkLightCurve(eqx.Module):
                 sight with positive values pointing *away* from the observer.
                 For an example, take a look at :class:`orbits.keplerian`.
             time: The time where the light curve should be evaluated.
-            order: The quadrature order passed to the
+            ld_order: The quadrature order passed to the
                 ``scipy.special.roots_legendre`` function in ``core.limb_dark.py``
                 which implements Gauss-Legendre quadrature. Defaults to 10.
         """
@@ -59,13 +64,59 @@ class LimbDarkLightCurve(eqx.Module):
         x, y, z = orbit.relative_position(time)
         b = jnpu.sqrt(x**2 + y**2) / r_star  # type: ignore
         r = orbit.radius / r_star
-        lc_func = partial(light_curve, self.u, order=order)
+        lc_func = partial(light_curve, self.u, order=ld_order)
         lc: Array = lc_func(b.magnitude, r.magnitude)
         lc = jnp.where(z > 0, lc, 0)
 
         return lc
 
+    def _light_curve(
+        self, orbit: LightCurveOrbit, time: Quantity, *, ld_order: int = 10
+    ) -> Quantity:
+        return self(orbit, time, ld_order=ld_order)
+
     def light_curve(
-        self, orbit: LightCurveOrbit, time: Quantity, *, order: int = 10
+        self, orbit: LightCurveOrbit, time: Quantity, *, ld_order: int = 10
     ) -> Array:
-        return self(orbit, time, order=order)
+        def _lc_func(time: time) -> _LightCurveFunc[T]:
+            return self._light_curve(orbit=orbit, time=time, ld_order=ld_order)
+
+        return jax.vmap(_lc_func, in_axes=(0))(time)
+
+    def _integrated_light_curve(
+        self,
+        orbit: LightCurveOrbit,
+        time: Quantity,
+        *,
+        ld_order: int = 10,
+        exposure_time: Optional[Quantity] = None,
+        order: int = 0,
+        num_samples: int = 7,
+    ) -> _LightCurveFunc[T]:
+        def _partial_lc_func(time):
+            return self._light_curve(orbit=orbit, time=time, ld_order=ld_order)
+
+        _integrated_lc_func = integrate_exposure_time(
+            _partial_lc_func, exposure_time=exposure_time, num_samples=num_samples
+        )
+        return _integrated_lc_func
+
+    def integrated_light_curve(
+        self,
+        orbit: LightCurveOrbit,
+        time: Quantity,
+        *,
+        ld_order: int = 10,
+        exposure_time: Optional[Quantity] = None,
+        order: int = 0,
+        num_samples: int = 7,
+    ) -> Array:
+        _integrated_lc_func = self._integrated_light_curve(
+            orbit=orbit,
+            time=time,
+            ld_order=ld_order,
+            exposure_time=exposure_time,
+            order=order,
+            num_samples=num_samples,
+        )
+        return jax.vmap(_integrated_lc_func, in_axes=(0))(time)

--- a/src/jaxoplanet/light_curves.py
+++ b/src/jaxoplanet/light_curves.py
@@ -1,60 +1,30 @@
 from functools import partial
-from typing import Optional, TypeVar
+from typing import Callable
 
-import equinox as eqx
-import jax
 import jax.numpy as jnp
 import jpu.numpy as jnpu
 
 from jaxoplanet import units
-from jaxoplanet.core.limb_dark import light_curve
-from jaxoplanet.exposure_time import _LightCurveFunc, integrate_exposure_time
+from jaxoplanet.core.limb_dark import light_curve as _limb_dark_light_curve
 from jaxoplanet.proto import LightCurveOrbit
 from jaxoplanet.types import Array, Quantity
 from jaxoplanet.units import unit_registry as ureg
 
-T = TypeVar("T", Array, Quantity, covariant=True)
 
-
-class LimbDarkLightCurve(eqx.Module):
-    """A light curve"""
-
-    u: Array
-
-    def __init__(self, *u: Array):
-        if u:
-            self.u = jnp.concatenate([jnp.atleast_1d(u0) for u0 in u], axis=0)
-        else:
-            self.u = jnp.array([])
+def light_curve(
+    orbit: LightCurveOrbit, *u: Array, order: int = 10
+) -> Callable[[Quantity], Array]:
+    if u:
+        ld_u = jnp.concatenate(u, axis=0)
+    else:
+        ld_u = jnp.array([])
 
     @units.quantity_input(time=ureg.d)
-    def __call__(
-        self,
-        orbit: LightCurveOrbit,
-        time: Quantity,
-        *,
-        ld_order: int = 10,
-    ) -> Array:
-        """Get the light curve for an orbit at a set of times
-
-        Args:
-            orbit: An object with a ``relative_position`` method that
-                takes a tensor of times and returns a list of Cartesian
-                coordinates of a set of bodies relative to the central source.
-                The first two coordinate dimensions are treated as being in
-                the plane of the sky and the third coordinate is the line of
-                sight with positive values pointing *away* from the observer.
-                For an example, take a look at :class:`orbits.keplerian`.
-            time: The time where the light curve should be evaluated.
-            ld_order: The quadrature order passed to the
-                ``scipy.special.roots_legendre`` function in ``core.limb_dark.py``
-                which implements Gauss-Legendre quadrature. Defaults to 10.
-        """
-
-        if jnpu.ndim(time) != 0:  # type: ignore
+    def light_curve_impl(time: Quantity) -> Array:
+        if jnpu.ndim(time) != 0:
             raise ValueError(
                 "The time passed to 'light_curve' has shape "
-                f"{jnpu.shape(time)}, but a scalar was expected; "  # type: ignore
+                f"{jnpu.shape(time)}, but a scalar was expected; "
                 "To use exposure time integration for an array of times, "
                 "manually 'vmap' or 'vectorize' the function"
             )
@@ -62,61 +32,16 @@ class LimbDarkLightCurve(eqx.Module):
         # Evaluate the coordinates of the transiting body
         r_star = orbit.central_radius
         x, y, z = orbit.relative_position(time)
-        b = jnpu.sqrt(x**2 + y**2) / r_star  # type: ignore
+
+        b = jnpu.sqrt(x**2 + y**2) / r_star
+        assert b.units == ureg.dimensionless
         r = orbit.radius / r_star
-        lc_func = partial(light_curve, self.u, order=ld_order)
-        lc: Array = lc_func(b.magnitude, r.magnitude)
+        assert r.units == ureg.dimensionless
+
+        lc_func = partial(_limb_dark_light_curve, ld_u, order=order)
+        lc = lc_func(b.magnitude, r.magnitude)
         lc = jnp.where(z > 0, lc, 0)
 
         return lc
 
-    def _light_curve(
-        self, orbit: LightCurveOrbit, time: Quantity, *, ld_order: int = 10
-    ) -> Quantity:
-        return self(orbit, time, ld_order=ld_order)
-
-    def light_curve(
-        self, orbit: LightCurveOrbit, time: Quantity, *, ld_order: int = 10
-    ) -> Array:
-        def _lc_func(time: Quantity) -> _LightCurveFunc[T]:
-            return self._light_curve(orbit=orbit, time=time, ld_order=ld_order)
-
-        return jax.vmap(_lc_func, in_axes=(0))(time).T
-
-    def _integrated_light_curve(
-        self,
-        orbit: LightCurveOrbit,
-        time: Quantity,
-        *,
-        ld_order: int = 10,
-        exposure_time: Optional[Quantity] = None,
-        order: int = 0,
-        num_samples: int = 7,
-    ) -> _LightCurveFunc[T]:
-        def _lc_func(time: Quantity) -> _LightCurveFunc[T]:
-            return self._light_curve(orbit=orbit, time=time, ld_order=ld_order)
-
-        _integrated_lc_func = integrate_exposure_time(
-            _lc_func, exposure_time=exposure_time, num_samples=num_samples
-        )
-        return _integrated_lc_func
-
-    def integrated_light_curve(
-        self,
-        orbit: LightCurveOrbit,
-        time: Quantity,
-        *,
-        ld_order: int = 10,
-        exposure_time: Optional[Quantity] = None,
-        order: int = 0,
-        num_samples: int = 7,
-    ) -> Array:
-        _integrated_lc_func = self._integrated_light_curve(
-            orbit=orbit,
-            time=time,
-            ld_order=ld_order,
-            exposure_time=exposure_time,
-            order=order,
-            num_samples=num_samples,
-        )
-        return jax.vmap(_integrated_lc_func, in_axes=(0))(time).T
+    return light_curve_impl

--- a/src/jaxoplanet/light_curves.py
+++ b/src/jaxoplanet/light_curves.py
@@ -11,11 +11,11 @@ from jaxoplanet.types import Array, Quantity
 from jaxoplanet.units import unit_registry as ureg
 
 
-def light_curve(
+def limb_dark_light_curve(
     orbit: LightCurveOrbit, *u: Array, order: int = 10
 ) -> Callable[[Quantity], Array]:
     if u:
-        ld_u = jnp.concatenate(u, axis=0)
+        ld_u = jnp.concatenate([jnp.atleast_1d(jnp.asarray(u_)) for u_ in u], axis=0)
     else:
         ld_u = jnp.array([])
 

--- a/tests/light_curves_test.py
+++ b/tests/light_curves_test.py
@@ -23,4 +23,4 @@ def test_light_curve():
     # Compute a limb-darkened light curve using jaxoplanet
     t = jnp.linspace(-0.3, 0.3, 1000)
     lc = jax.vmap(limb_dark_light_curve(orbit, params["u"]))(t)
-    assert lc.shape == (1,) + t.shape
+    assert lc.shape == t.shape + (1,)

--- a/tests/light_curves_test.py
+++ b/tests/light_curves_test.py
@@ -1,7 +1,8 @@
+import jax
 import jax.numpy as jnp
 
-from jaxoplanet.light_curves import LimbDarkLightCurve
-from jaxoplanet.orbits.keplerian import Central, System
+from jaxoplanet.orbits.keplerian import System
+from jaxoplanet.light_curves import limb_dark_light_curve
 
 
 def test_light_curve():
@@ -21,21 +22,5 @@ def test_light_curve():
 
     # Compute a limb-darkened light curve using jaxoplanet
     t = jnp.linspace(-0.3, 0.3, 1000)
-
-    lc = LimbDarkLightCurve(params["u"]).light_curve(orbit, t=t)
-    assert lc.shape == (1,) + t.shape
-
-
-def test_multiplanetary():
-    star = Central(mass=5, radius=2)
-    system = System(star).add_body(radius=0.05, period=1).add_body(radius=0.2, period=2)
-
-    t = jnp.linspace(-5, 5, 500)
-    lc = LimbDarkLightCurve().light_curve(system, t)
-    lc_texp_scalar = LimbDarkLightCurve().light_curve(system, t, texp=10)
-    lc_texp_array = LimbDarkLightCurve().light_curve(
-        system, t, texp=jnp.broadcast_to(10, t.size)
-    )
-    assert lc.shape == (system.shape[0], t.size)
-    assert lc_texp_scalar.shape == (system.shape[0], t.size)
-    assert lc_texp_array.shape == (system.shape[0], t.size)
+    lc = jax.vmap(limb_dark_light_curve(orbit, params["u"]))(t)
+    assert lc.shape == t.shape

--- a/tests/light_curves_test.py
+++ b/tests/light_curves_test.py
@@ -23,4 +23,4 @@ def test_light_curve():
     # Compute a limb-darkened light curve using jaxoplanet
     t = jnp.linspace(-0.3, 0.3, 1000)
     lc = jax.vmap(limb_dark_light_curve(orbit, params["u"]))(t)
-    assert lc.shape == t.shape
+    assert lc.shape == (1,) + t.shape

--- a/tests/light_curves_test.py
+++ b/tests/light_curves_test.py
@@ -1,8 +1,8 @@
 import jax
 import jax.numpy as jnp
 
-from jaxoplanet.orbits.keplerian import System
 from jaxoplanet.light_curves import limb_dark_light_curve
+from jaxoplanet.orbits.keplerian import System
 
 
 def test_light_curve():


### PR DESCRIPTION
@soichiro-hattori — Check this out! I think this is potentially cool, and might simplify some of our logic around light curve models. Basically the idea is that we can factor the exposure time integration out of the `LightCurve` object into a function transformation. This is a bit more "JAX-y" and means that we could support different kinds of light curve models more easily. The use would look something like:

```python
import jax
import jax.numpy as jnp

from jaxoplanet.orbits import keplerian
from jaxoplanet.light_curves import LimbDarkLightCurve
from jaxoplanet.exposure_time import integrate_exposure_time


central = keplerian.Central(mass=5, radius=2)
system = keplerian.System(central).add_body(radius=0.05, period=3.0)

def light_curve(time):
    return LimbDarkLightCurve().light_curve(system, time)[0, 0]

integrated_light_curve = integrate_exposure_time(light_curve, exposure_time=0.1, num_samples=15)
t = jnp.linspace(-5, 5, 5000)
lc = jax.vmap(integrated_light_curve)(t)
```

The new `integrate_exposure_time` function operates on any function which takes a scalar time as an argument and calls that function vmapped onto the appropriate time grid to integrate.

What do you think??