### PR TITLE
Factoring the "body stack" logic out to a generic "object stack"

### DIFF
--- a/src/jaxoplanet/object_stack.py
+++ b/src/jaxoplanet/object_stack.py
@@ -1,0 +1,143 @@
+from collections.abc import Callable, Sequence
+from functools import wraps
+from typing import Any, Generic, Optional, TypeVar, Union
+
+import equinox as eqx
+import jax
+import jax.numpy as jnp
+import jpu.numpy as jnpu
+from jax.interpreters import batching
+from jax.tree_util import tree_flatten
+
+try:
+    from jax.extend import linear_util as lu
+except ImportError:
+    from jax import linear_util as lu  # type: ignore
+
+Obj = TypeVar("Obj")
+
+
+class ObjectStack(eqx.Module, Generic[Obj]):
+    objects: tuple[Obj, ...]
+    stack: Optional[Obj]
+
+    def __init__(self, *objects: Obj):
+        self.objects = objects
+
+        # If all the objects have matching Pytree structure then we save a
+        # stacked version that we can use for vmaps below. This allows for more
+        # efficient evaluations in the case of multiple objects.
+        self.stack = None
+        if len(self.objects):
+            spec = list(map(jax.tree_util.tree_structure, self.objects))
+            if spec.count(spec[0]) == len(spec):
+                self.stack = jax.tree_util.tree_map(
+                    lambda *x: jnp.stack(x, axis=0), *self.objects
+                )
+
+    def __len__(self) -> int:
+        return len(self.objects)
+
+    def vmap(
+        self,
+        func: Callable,
+        in_axes: Union[int, None, Sequence[Any]] = 0,
+        out_axes: Any = 0,
+    ) -> Callable:
+        """Map a function over the bodies of this system
+
+        If possible, this method will apply the appropriate ``jax.vmap`` to the input
+        function, but if the Pytree structure of the bodies don't match, this requires
+        a loop over bodies, applying the function separately to each body, and stacking
+        the results.
+
+        Args:
+            func: The function to map. It's first positional argument must accept a
+                Keplerian :class:`Body` object.
+            in_axes: The input axis specifications for all arguments after the first.
+                The semantics should match ``jax.vmap``.
+            out_axes: The output axis specifications, matching ``jax.vmap``.
+
+        Returns:
+            The vectorized version of ``func`` mapped over bodies in this system.
+
+        For example, if (for some reason) we wanted to compute the $x$ positions of all
+        the bodies in a system at a particular time, in units of the body radius, we
+        could use the following:
+
+        >>> from jaxoplanet.orbits.keplerian import Central, System
+        >>> sys = System(Central())
+        >>> sys = sys.add_body(period=1.0, radius=0.1)
+        >>> sys = sys.add_body(period=2.0, radius=0.2)
+        >>> pos = sys.body_vmap(
+        ...     lambda body, t: body.position(t)[0] / body.radius,
+        ...     in_axes=None,
+        ... )
+        >>> pos(0.2)
+        <Quantity([40.0231   19.632687], 'dimensionless')>
+        """
+
+        @wraps(func)
+        def impl(*args):
+            # First, normalize the "in_axes" argument so we always have an iterable
+            if isinstance(in_axes, Sequence):
+                in_axes_ = tuple(in_axes)
+            else:
+                in_axes_ = tuple(in_axes for _ in args)
+
+            # If we have a "body_stack" we can just vmap and be done
+            if self.stack is not None:
+                return jax.vmap(func, in_axes=(0,) + in_axes_, out_axes=out_axes)(
+                    self.stack, *args
+                )
+
+            # Otherwise we need to loop over the bodies and apply the function once for
+            # each body
+
+            # Here we flatten the input arguments and `in_axes` so that we don't have
+            # to deal with Pytree logic for the `in_axes` ourselves below.
+            args_flat, in_tree = tree_flatten(args, is_leaf=batching.is_vmappable)
+            in_axes_flat = jax.api_util.flatten_axes(  # type: ignore
+                "body_vmap in_axes", in_tree, in_axes_
+            )
+
+            # Then loop over the bodies and accumulate the function results
+            results = []
+            out_tree = None
+            for n, body in enumerate(self.objects):
+                f = lu.wrap_init(func)
+                f, out_tree_ = flatten_func_for_object_vmap(f, in_tree, in_axes_flat, n)
+                results.append(f.call_wrapped(body, *args_flat))  # type: ignore
+                out_tree_ = out_tree_()  # type: ignore
+                if out_tree is not None and out_tree_ != out_tree:
+                    raise ValueError(
+                        "Input function does not return consistent Pytree structure;\n"
+                        f"expected: {out_tree}\n"
+                        f"found: {out_tree_}\n"
+                    )
+                out_tree = out_tree_
+
+            out_axes_flat = jax.api_util.flatten_axes(  # type: ignore
+                "body_vmap out_axes", out_tree, out_axes
+            )
+            return out_tree.unflatten(  # type: ignore
+                parts[0] if a is None else jnpu.stack(parts, axis=a)
+                for a, *parts in zip(out_axes_flat, *results)  # type: ignore
+            )
+
+        return impl
+
+
+def index_helper(n, arg, axis):
+    if axis is None:
+        return arg
+    else:
+        idx = (slice(None),) * axis + (n,)
+        return arg[idx]
+
+
+@lu.transformation_with_aux  # type: ignore
+def flatten_func_for_object_vmap(in_tree, in_axes_flat, index, body, *args_flat):
+    args_indexed = (index_helper(index, *args) for args in zip(args_flat, in_axes_flat))
+    ans = yield (body,) + in_tree.unflatten(args_indexed), {}
+    yield tree_flatten(ans, is_leaf=batching.is_vmappable)

--- a/src/jaxoplanet/orbits/keplerian.py
+++ b/src/jaxoplanet/orbits/keplerian.py
@@ -1,24 +1,17 @@
 from collections.abc import Iterable, Sequence
-from functools import wraps
 from typing import Any, Callable, Optional, Union
 
 import equinox as eqx
 import jax
 import jax.numpy as jnp
 import jpu.numpy as jnpu
-from jax.interpreters import batching
-from jax.tree_util import tree_flatten
 
 from jaxoplanet import units
 from jaxoplanet.core.kepler import kepler
 from jaxoplanet.experimental.starry.maps import Map
+from jaxoplanet.object_stack import ObjectStack
 from jaxoplanet.types import Quantity
 from jaxoplanet.units import unit_registry as ureg
-
-try:
-    from jax.extend import linear_util as lu
-except ImportError:
-    from jax import linear_util as lu  # type: ignore
 
 
 class Central(eqx.Module):
@@ -698,18 +691,11 @@ class OrbitalBody(eqx.Module):
         return (x, y, z), (vx, vy, vz)
 
 
-class BodyStack(eqx.Module):
-    """A computational tool"""
-
-    stack: OrbitalBody
-
-
 class System(eqx.Module):
     """A Keplerian orbital system"""
 
     central: Central
-    bodies: tuple[OrbitalBody, ...]
-    _body_stack: Optional[BodyStack]
+    _body_stack: ObjectStack[OrbitalBody]
 
     def __init__(
         self,
@@ -718,32 +704,25 @@ class System(eqx.Module):
         bodies: Iterable[Union[Body, OrbitalBody]] = (),
     ):
         self.central = Central() if central is None else central
-        self.bodies = tuple(
-            b if isinstance(b, OrbitalBody) else OrbitalBody(self.central, b)
-            for b in bodies
+        self._body_stack = ObjectStack(
+            *(
+                b if isinstance(b, OrbitalBody) else OrbitalBody(self.central, b)
+                for b in bodies
+            )
         )
-
-        # If all the bodies have matching Pytree structure then we save a
-        # stacked version that we can use for vmaps below. This allows for more
-        # efficient evaluations in the case of multiple bodies.
-        self._body_stack = None
-        if len(self.bodies):
-            spec = list(map(jax.tree_util.tree_structure, self.bodies))
-            if spec.count(spec[0]) == len(spec):
-                self._body_stack = BodyStack(
-                    stack=jax.tree_util.tree_map(
-                        lambda *x: jnp.stack(x, axis=0), *self.bodies
-                    )
-                )
 
     def __repr__(self) -> str:
         return eqx.tree_pformat(
-            self, truncate_leaf=lambda obj: isinstance(obj, BodyStack)
+            self, truncate_leaf=lambda obj: isinstance(obj, ObjectStack)
         )
 
     @property
     def shape(self) -> tuple[int, ...]:
-        return (len(self.bodies),)
+        return (len(self._body_stack),)
+
+    @property
+    def bodies(self) -> tuple[OrbitalBody, ...]:
+        return self._body_stack.objects
 
     @property
     def radius(self) -> Quantity:
@@ -757,7 +736,7 @@ class System(eqx.Module):
     def map(self):
         return jax.tree_util.tree_map(
             lambda *x: jnp.stack(x, axis=0),
-            *[body.map for body in self.bodies],
+            *[body.map for body in self._body_stack.objects],
         )
 
     def add_body(self, body: Optional[Body] = None, **kwargs: Any) -> "System":
@@ -803,56 +782,7 @@ class System(eqx.Module):
         >>> pos(0.2)
         <Quantity([40.0231   19.632687], 'dimensionless')>
         """
-
-        @wraps(func)
-        def impl(*args):
-            # First, normalize the "in_axes" argument so we always have an iterable
-            if isinstance(in_axes, Sequence):
-                in_axes_ = tuple(in_axes)
-            else:
-                in_axes_ = tuple(in_axes for _ in args)
-
-            # If we have a "body_stack" we can just vmap and be done
-            if self._body_stack is not None:
-                return jax.vmap(func, in_axes=(0,) + in_axes_, out_axes=out_axes)(
-                    self._body_stack.stack, *args
-                )
-
-            # Otherwise we need to loop over the bodies and apply the function once for
-            # each body
-
-            # Here we flatten the input arguments and `in_axes` so that we don't have
-            # to deal with Pytree logic for the `in_axes` ourselves below.
-            args_flat, in_tree = tree_flatten(args, is_leaf=batching.is_vmappable)
-            in_axes_flat = jax.api_util.flatten_axes(  # type: ignore
-                "body_vmap in_axes", in_tree, in_axes_
-            )
-
-            # Then loop over the bodies and accumulate the function results
-            results = []
-            out_tree = None
-            for n, body in enumerate(self.bodies):
-                f = lu.wrap_init(func)
-                f, out_tree_ = flatten_func_for_body_vmap(f, in_tree, in_axes_flat, n)
-                results.append(f.call_wrapped(body, *args_flat))  # type: ignore
-                out_tree_ = out_tree_()  # type: ignore
-                if out_tree is not None and out_tree_ != out_tree:
-                    raise ValueError(
-                        "Input function does not return consistent Pytree structure;\n"
-                        f"expected: {out_tree}\n"
-                        f"found: {out_tree_}\n"
-                    )
-                out_tree = out_tree_
-
-            out_axes_flat = jax.api_util.flatten_axes(  # type: ignore
-                "body_vmap out_axes", out_tree, out_axes
-            )
-            return out_tree.unflatten(  # type: ignore
-                parts[0] if a is None else jnp.stack(parts, axis=a)
-                for a, *parts in zip(out_axes_flat, *results)  # type: ignore
-            )
-
-        return impl
+        return self._body_stack.vmap(func, in_axes=in_axes, out_axes=out_axes)
 
     def position(self, t: Quantity) -> tuple[Quantity, Quantity, Quantity]:
         return self.body_vmap(OrbitalBody.position, in_axes=None)(t)
@@ -874,18 +804,3 @@ class System(eqx.Module):
 
     def radial_velocity(self, t: Quantity) -> Quantity:
         return self.body_vmap(OrbitalBody.radial_velocity, in_axes=None)(t)
-
-
-def index_helper(n, arg, axis):
-    if axis is None:
-        return arg
-    else:
-        idx = (slice(None),) * axis + (n,)
-        return arg[idx]
-
-
-@lu.transformation_with_aux  # type: ignore
-def flatten_func_for_body_vmap(in_tree, in_axes_flat, index, body, *args_flat):
-    args_indexed = (index_helper(index, *args) for args in zip(args_flat, in_axes_flat))
-    ans = yield (body,) + in_tree.unflatten(args_indexed), {}
-    yield tree_flatten(ans, is_leaf=batching.is_vmappable)

--- a/tests/object_stack_test.py
+++ b/tests/object_stack_test.py
@@ -1,0 +1,55 @@
+import jax.numpy as jnp
+import pytest
+
+from jaxoplanet.object_stack import ObjectStack
+from jaxoplanet.test_utils import assert_quantity_pytree_allclose
+
+
+def f1(x):
+    return x["a"] ** 2
+
+
+def f2(x):
+    return {"y": x["a"] ** 2}
+
+
+@pytest.mark.parametrize(
+    "func, objects, result",
+    [
+        (
+            f1,
+            (
+                {"a": 0.5},
+                {"a": 0.1},
+            ),
+            jnp.asarray([0.5**2, 0.1**2]),
+        ),
+        (
+            f1,
+            (
+                {"a": 0.5},
+                {"a": 0.1, "b": 1000.0},
+            ),
+            jnp.asarray([0.5**2, 0.1**2]),
+        ),
+        (
+            f2,
+            (
+                {"a": 0.5},
+                {"a": 0.1},
+            ),
+            {"y": jnp.asarray([0.5**2, 0.1**2])},
+        ),
+        (
+            f2,
+            (
+                {"a": 0.5},
+                {"a": 0.1, "b": 1000.0},
+            ),
+            {"y": jnp.asarray([0.5**2, 0.1**2])},
+        ),
+    ],
+)
+def test_object_stack(func, objects, result):
+    stack = ObjectStack(*objects)
+    assert_quantity_pytree_allclose(stack.vmap(func)(), result)

--- a/tests/orbits/keplerian_test.py
+++ b/tests/orbits/keplerian_test.py
@@ -175,7 +175,7 @@ def test_keplerian_body_positions_small_star(time):
 
 def test_keplerian_system_stack_construction():
     sys = System().add_body(period=0.1).add_body(period=0.2)
-    assert sys._body_stack is not None
+    assert sys._body_stack.stack is not None
     assert_quantity_allclose(
         sys._body_stack.stack.period, jnp.array([0.1, 0.2]) * ureg.day
     )
@@ -185,7 +185,7 @@ def test_keplerian_system_stack_construction():
         .add_body(period=0.1)
         .add_body(period=0.2, eccentricity=0.1, omega_peri=-1.5)
     )
-    assert sys._body_stack is None
+    assert sys._body_stack.stack is None
 
 
 def test_keplerian_system_radial_velocity():
@@ -195,8 +195,8 @@ def test_keplerian_system_radial_velocity():
         .add_body(period=0.1)
         .add_body(period=0.2, eccentricity=0.0, omega_peri=0.0)
     )
-    assert sys1._body_stack is not None
-    assert sys2._body_stack is None
+    assert sys1._body_stack.stack is not None
+    assert sys2._body_stack.stack is None
     with pytest.raises(ValueError):
         sys1._body_stack.stack.radial_velocity(0.0)
 


### PR DESCRIPTION
As part of #134, I wanted to move the body stack logic to a separate object. This means that we can reuse the same logic for a stack of "maps" without reimplementing it.