### PR TITLE
Minor starry fixes

### DIFF
--- a/src/jaxoplanet/experimental/starry/maps.py
+++ b/src/jaxoplanet/experimental/starry/maps.py
@@ -70,6 +70,9 @@ class Map(eqx.Module):
     # Amplitude of the map, a quantity proportional to map luminosity.
     amplitude: Array
 
+    # Boolean to specify whether the Ylm coefficients should be normalized
+    normalize: bool
+
     def __init__(
         self,
         *,

--- a/src/jaxoplanet/experimental/starry/maps.py
+++ b/src/jaxoplanet/experimental/starry/maps.py
@@ -23,7 +23,8 @@ class Map(eqx.Module):
         y (Optional[Union[Ylm, float]], optional): Ylm object containing the
         spherical harmonic expansion of the map. Defaults to None (a uniform map)
         with amplitude 1.0.
-        inc (Optional[float], optional): inclination of the map. Defaults to 0.
+        inc (Optional[float], optional): inclination of the map relative
+        to line of sight. Defaults to 90 degrees (pi/2 radians).
         obl (Optional[float], optional): obliquity iof the map. Defaults to 0.
         u (Optional[tuple], optional): polynomial limb-darkening coefficients of
         the map. Defaults to ().
@@ -111,6 +112,7 @@ class Map(eqx.Module):
         self.u = u
         self.period = period
         self.amplitude = amplitude
+        self.normalize = normalize
 
     @property
     def poly_basis(self):

--- a/src/jaxoplanet/experimental/starry/maps.py
+++ b/src/jaxoplanet/experimental/starry/maps.py
@@ -90,7 +90,7 @@ class Map(eqx.Module):
 
         if normalize:
             amplitude = float(y[(0, 0)])
-            y = Ylm(data=y.data, normalize=True)
+            y = Ylm(data=y.data).normalize()
 
         self.y = y
         self.inc = inc

--- a/src/jaxoplanet/experimental/starry/maps.py
+++ b/src/jaxoplanet/experimental/starry/maps.py
@@ -103,7 +103,7 @@ class Map(eqx.Module):
             normalize = True
 
         if normalize:
-            amplitude = y[(0, 0)]
+            amplitude = float(y[(0, 0)])
             y = Ylm(data=y.data, normalize=True)
 
         self.y = y

--- a/src/jaxoplanet/experimental/starry/ylm.py
+++ b/src/jaxoplanet/experimental/starry/ylm.py
@@ -21,11 +21,6 @@ class Ylm(eqx.Module):
     Args:
         data (Mapping[tuple[int, int], Array], optional): dictionary of
             spherical harmonic coefficients. Defaults to {(0, 0): 1.0}.
-        normalize (bool, optional): Whether to normalize the coefficients by the
-            value of the (0, 0) coefficient. Defaults to True.
-
-    Raises:
-        ValueError: if normalize is True and the (0, 0) coefficient is zero.
     """
 
     # coefficients of the spherical harmonic expansion of the map in the form
@@ -41,16 +36,10 @@ class Ylm(eqx.Module):
     def __init__(
         self,
         data: Optional[Mapping[tuple[int, int], Array]] = None,
-        normalize: bool = True,
     ):
         if data is None:
             data = {(0, 0): 1.0}
 
-        if normalize:
-            assert data[(0, 0)] != 0.0, ValueError(
-                "The (0, 0) coefficient must be non-zero if normalize=True"
-            )
-            data = {k: v / data[(0, 0)] for k, v in data.items()}
         self.data = dict(data)
         self.ell_max = max(ell for ell, _ in data.keys())
         self.diagonal = all(m == 0 for _, m in data.keys())
@@ -69,6 +58,22 @@ class Ylm(eqx.Module):
         """Convert the degree and order of the spherical harmonic to the
         corresponding index in the coefficient array."""
         return ell * (ell + 1) + m
+
+    def normalize(self) -> "Ylm":
+        """Return a new Ylm instance with normalized coefficients.
+
+        Returns:
+            Ylm instance with normalized coefficients.
+
+        Raises:
+            ValueError: if the (0, 0) coefficient is zero.
+        """
+
+        assert self.data[(0, 0)] != 0.0, ValueError(
+            "The (0, 0) coefficient must be non-zero to normalize"
+        )
+        data = {k: v / self.data[(0, 0)] for k, v in self.data.items()}
+        return Ylm(data=data)
 
     def tosparse(self) -> BCOO:
         indices, values = zip(*self.data.items())

--- a/src/jaxoplanet/experimental/starry/ylm.py
+++ b/src/jaxoplanet/experimental/starry/ylm.py
@@ -90,7 +90,11 @@ class Ylm(eqx.Module):
             ell = int(np.floor(np.sqrt(i)))
             m = i - ell * (ell + 1)
             data[(ell, m)] = ylm
-        return cls(data, normalize=normalize)
+        ylm = cls(data)
+        if normalize:
+            return ylm.normalize()
+        else:
+            return ylm
 
     def __mul__(self, other: Any) -> "Ylm":
         if isinstance(other, Ylm):

--- a/src/jaxoplanet/experimental/starry/ylm.py
+++ b/src/jaxoplanet/experimental/starry/ylm.py
@@ -21,11 +21,11 @@ class Ylm(eqx.Module):
     Args:
         data (Mapping[tuple[int, int], Array], optional): dictionary of
             spherical harmonic coefficients. Defaults to {(0, 0): 1.0}.
-        relative (bool, optional): Whether to normalize the coefficients by the
+        normalize (bool, optional): Whether to normalize the coefficients by the
             value of the (0, 0) coefficient. Defaults to True.
 
     Raises:
-        ValueError: if relative is True and the (0, 0) coefficient is zero.
+        ValueError: if normalize is True and the (0, 0) coefficient is zero.
     """
 
     # coefficients of the spherical harmonic expansion of the map in the form
@@ -48,7 +48,7 @@ class Ylm(eqx.Module):
 
         if normalize:
             assert data[(0, 0)] != 0.0, ValueError(
-                "The (0, 0) coefficient must be non-zero if relative=True"
+                "The (0, 0) coefficient must be non-zero if normalize=True"
             )
             data = {k: v / data[(0, 0)] for k, v in data.items()}
         self.data = dict(data)


### PR DESCRIPTION
This PR fixes some minor bugs and docs issues in the starry module.

1. Update doc for `inc` argument in `Map` class to mention that it's initialized at 90 degrees (not 0) and that the angle is measured relative to the line of sight.
2. Add `self.normalize=normalize` in `Map` initialization so that it's string representation isn't `None`.
3. Fix doc mentions of `relative` in `Ylm` since we call it `normalize`.
4. In `Map` initialization, when in `normalize=True` block, cast `y[(0,0)]` to `float` as it's otherwise a JAX `ArrayImpl` that doesn't show the value in the string representation.