### PR TITLE
Remove numpyro version bound

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ docs = [
     "matplotlib",
     "arviz",
     "corner",
-    "numpyro<0.14",
+    "numpyro",
     "numpyro-ext",
     "jaxopt",
     "myst-nb",


### PR DESCRIPTION
The numpyro compatibility issue was fixed in https://github.com/dfm/numpyro-ext/pull/32 by @vandalt. 

Fixes #160