### PR TITLE
feat: faster rotation decomposition + refactor axis angle functions

### DIFF
--- a/src/jaxoplanet/experimental/starry/rotation.py
+++ b/src/jaxoplanet/experimental/starry/rotation.py
@@ -5,6 +5,7 @@ import jax
 import jax.numpy as jnp
 
 from jaxoplanet.utils import get_dtype_eps
+from jaxoplanet.types import Array
 
 
 def dot_rotation_matrix(ydeg, x, y, z, theta):
@@ -67,7 +68,19 @@ def dot_rotation_matrix(ydeg, x, y, z, theta):
     return do_dot
 
 
-def right_project_axis_angle(inc, obl, theta, theta_z):
+def full_rotation_axis_angle(inc: float, obl: float, theta: float, theta_z: float):
+    """Return the axis-angle representation of the full rotation of the
+       spherical harmonic map
+
+    Args:
+        inc (float): map inclination
+        obl (float): map obliquity
+        theta (float): rotation angle about the map z-axis
+        theta_z (float): rotation angle about the sky y-axis
+
+    Returns:
+        tuple: x, y, z, angle
+    """
     f = 0.5 * math.sqrt(2)
     si = jnp.sin(inc / 2)
     ci = jnp.cos(inc / 2)
@@ -94,14 +107,84 @@ def right_project_axis_angle(inc, obl, theta, theta_z):
     return axis_x, axis_y, axis_z, angle
 
 
-def right_project(ydeg, inc, obl, theta, theta_z, x):
-    axis_x, axis_y, axis_z, angle = right_project_axis_angle(inc, obl, theta, theta_z)
-    return dot_rotation_matrix(ydeg, axis_x, axis_y, axis_z, angle)(x)
+def sky_projection_axis_angle(inc: float, obl: float):
+    """Return the axis-angle representation of the partial rotation of the
+       map due to inclination and obliquity
+
+    Args:
+        inc (float): map inclination
+        obl (float): map obliquity
+
+    Returns:
+        tuple: x, y, z, angle
+    """
+    co = jnp.cos(obl / 2)
+    so = jnp.sin(obl / 2)
+    ci = jnp.cos(inc / 2)
+    si = jnp.sin(inc / 2)
+
+    denominator = jnp.sqrt(1 - ci**2 * co**2)
+
+    axis_x = si * co
+    axis_y = si * so
+    axis_z = -so * ci
+
+    angle = 2 * jnp.arccos(ci * co)
+
+    arg = jnp.linalg.norm(jnp.array([axis_x, axis_y, axis_z]))
+    axis_x = jnp.where(arg > 0, axis_x / denominator, 1.0)
+    axis_y = jnp.where(arg > 0, axis_y / denominator, 0.0)
+    axis_z = jnp.where(arg > 0, axis_z / denominator, 0.0)
+
+    return axis_x, axis_y, axis_z, angle
 
 
-def left_project(ydeg, inc, obl, theta, theta_z, x):
-    axis_x, axis_y, axis_z, angle = right_project_axis_angle(inc, obl, theta, theta_z)
-    return dot_rotation_matrix(ydeg, -axis_x, -axis_y, -axis_z, angle)(x)
+def left_project(
+    ydeg: int, inc: float, obl: float, theta: float, theta_z: float, y: Array
+):
+    """R @ y
+
+    Args:
+        ydeg (int): degree of the spherical harmonic map
+        inc (float): map inclination
+        obl (float): map obliquity
+        theta (float): rotation angle about the map z-axis
+        theta_z (float): rotation angle about the sky y-axis
+        x (Array): spherical harmonic map coefficients
+
+    Returns:
+        Array: rotated spherical harmonic map coefficients
+    """
+    axis_x, axis_y, axis_z, angle = sky_projection_axis_angle(inc, obl)
+    y = dot_rotation_matrix(ydeg, 1.0, None, None, -0.5 * jnp.pi)(y)
+    y = dot_rotation_matrix(ydeg, None, None, 1.0, -theta)(y)
+    y = dot_rotation_matrix(ydeg, axis_x, axis_y, axis_z, angle)(y)
+    y = dot_rotation_matrix(ydeg, None, None, 1.0, -theta_z)(y)
+    return y
+
+
+def right_project(
+    ydeg: int, inc: float, obl: float, theta: float, theta_z: float, y: Array
+):
+    """y @ R
+
+    Args:
+        ydeg (int): degree of the spherical harmonic map
+        inc (float): map inclination
+        obl (float): map obliquity
+        theta (float): rotation angle about the map z-axis
+        theta_z (float): rotation angle about the sky y-axis
+        x (Array): spherical harmonic map coefficients
+
+    Returns:
+        Array: rotated spherical harmonic map coefficients
+    """
+    axis_x, axis_y, axis_z, angle = sky_projection_axis_angle(inc, obl)
+    y = dot_rotation_matrix(ydeg, None, None, 1.0, theta_z)(y)
+    y = dot_rotation_matrix(ydeg, -axis_x, -axis_y, -axis_z, angle)(y)
+    y = dot_rotation_matrix(ydeg, None, None, 1.0, theta)(y)
+    y = dot_rotation_matrix(ydeg, 1.0, None, None, 0.5 * jnp.pi)(y)
+    return y
 
 
 @partial(jax.jit, static_argnums=(0,))

--- a/src/jaxoplanet/experimental/starry/rotation.py
+++ b/src/jaxoplanet/experimental/starry/rotation.py
@@ -4,8 +4,8 @@ from functools import partial
 import jax
 import jax.numpy as jnp
 
-from jaxoplanet.utils import get_dtype_eps
 from jaxoplanet.types import Array
+from jaxoplanet.utils import get_dtype_eps
 
 
 def dot_rotation_matrix(ydeg, x, y, z, theta):

--- a/src/jaxoplanet/experimental/starry/surface.py
+++ b/src/jaxoplanet/experimental/starry/surface.py
@@ -11,7 +11,7 @@ from jaxoplanet.experimental.starry.basis import A1, U0, poly_basis
 from jaxoplanet.experimental.starry.pijk import Pijk
 from jaxoplanet.experimental.starry.rotation import (
     left_project,
-    right_project_axis_angle,
+    full_rotation_axis_angle,
 )
 from jaxoplanet.experimental.starry.utils import ortho_grid
 from jaxoplanet.experimental.starry.ylm import Ylm
@@ -158,7 +158,7 @@ class Surface(eqx.Module):
         y = jnp.sin(lat) * jnp.sin(lon)
         z = jnp.cos(lat) * jnp.ones_like(x)
 
-        axis = right_project_axis_angle(self.inc - jnp.pi / 2, self.obl, 0.0, 0.0)
+        axis = full_rotation_axis_angle(self.inc - jnp.pi / 2, self.obl, 0.0, 0.0)
         axis = jnp.array(axis[0:3]) * axis[-1]
         rotation = Rotation.from_rotvec(axis)
         x, y, z = rotation.apply(jnp.array([x, y, z]).T).T

--- a/src/jaxoplanet/experimental/starry/surface.py
+++ b/src/jaxoplanet/experimental/starry/surface.py
@@ -10,8 +10,8 @@ from jax.scipy.spatial.transform import Rotation
 from jaxoplanet.experimental.starry.basis import A1, U0, poly_basis
 from jaxoplanet.experimental.starry.pijk import Pijk
 from jaxoplanet.experimental.starry.rotation import (
-    left_project,
     full_rotation_axis_angle,
+    left_project,
 )
 from jaxoplanet.experimental.starry.utils import ortho_grid
 from jaxoplanet.experimental.starry.ylm import Ylm

--- a/tests/experimental/starry/rotation_test.py
+++ b/tests/experimental/starry/rotation_test.py
@@ -7,7 +7,7 @@ from jaxoplanet.experimental.starry.rotation import (
     dot_rotation_matrix,
     left_project,
     right_project,
-    right_project_axis_angle,
+    full_rotation_axis_angle,
 )
 from jaxoplanet.test_utils import assert_allclose
 
@@ -62,7 +62,7 @@ def test_right_project_axis_angle_edge_case():
     theta = theta_z = obl = 0.0
     inc = jnp.pi / 2
 
-    x = jnp.array(right_project_axis_angle(inc, obl, theta, theta_z))
+    x = jnp.array(full_rotation_axis_angle(inc, obl, theta, theta_z))
     assert jnp.all(jnp.isfinite(x))
 
 

--- a/tests/experimental/starry/rotation_test.py
+++ b/tests/experimental/starry/rotation_test.py
@@ -5,9 +5,9 @@ import pytest
 
 from jaxoplanet.experimental.starry.rotation import (
     dot_rotation_matrix,
+    full_rotation_axis_angle,
     left_project,
     right_project,
-    full_rotation_axis_angle,
 )
 from jaxoplanet.test_utils import assert_allclose
 


### PR DESCRIPTION
Faster rotations of the spherical harmonics. This is described in the technical paper but the idea is to go from 6 rotations
<img width="796" alt="Screenshot 2024-06-14 at 1 57 03 PM" src="https://github.com/exoplanet-dev/jaxoplanet/assets/20612771/9d5a36fd-c177-48dd-9c31-ba722953094a">
to 4
<img width="760" alt="Screenshot 2024-06-14 at 1 56 42 PM" src="https://github.com/exoplanet-dev/jaxoplanet/assets/20612771/794fe62c-bd61-4b05-b1cd-cd9a159928a4">
In the previous implementation [I merged all rotations](#83), which ends up not being optimal (because of the rotation around y).

The combined rotation to orient the star in the plane of the sky is defined by the axis
```math
\begin{equation}
    v = \frac{1}{\sqrt{1 - \cos^2{\left(\frac{inc}{2} \right)} \cos^2{\left(\frac{obl}{2}\right)}}} \begin{pmatrix}
        \sin{\left(\frac{inc}{2} \right)} \cos{\left(\frac{obl}{2}\right)}\\
        \sin{\left(\frac{inc}{2} \right)} \sin{\left(\frac{obl}{2}\right)}\\
         - \cos{\left(\frac{inc}{2} \right)} \sin{\left(\frac{obl}{2}\right)}\\
    \end{pmatrix},
\end{equation}
```
and angle $\omega = 2 \cos^{-1}{\left(\cos{\left(\frac{inc}{2} \right)} \cos{\left(\frac{obl}{2}\right)} \right)}.$