### PR TITLE
Add maxdepth argument to toctrees in docs

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -5,6 +5,7 @@
 
 ```{toctree}
 :caption: User guide
+:maxdepth: 1
 
 install
 troubleshooting
@@ -13,6 +14,7 @@ tutorials/getting-started.ipynb
 
 ```{toctree}
 :caption: Tutorials
+:maxdepth: 1
 
 tutorials/about.ipynb
 tutorials/transit.ipynb
@@ -21,6 +23,7 @@ tutorials/rv.ipynb
 
 ```{toctree}
 :caption: Reference
+:maxdepth: 1
 
 api
 tutorials/autodiff.ipynb


### PR DESCRIPTION
I think the landing page is hard to parse otherwise...

Edited to add the rendered link: https://jaxoplanet--198.org.readthedocs.build/en/198/