### PR TITLE
feat: secondary/emission light curve of (limb-darkened) bodies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ classifiers = [
     "Programming Language :: Python :: 3",
 ]
 dynamic = ["version"]
-dependencies = ["jax", "jaxlib", "jpu>=0.0.2", "equinox", "pint"]
+dependencies = ["jax", "jaxlib", "jpu>=0.0.2", "equinox", "pint", "jax<=0.4.31"]
 
 [project.urls]
 "Homepage" = "https://jax.exoplanet.codes"

--- a/src/jaxoplanet/light_curves/emission.py
+++ b/src/jaxoplanet/light_curves/emission.py
@@ -1,0 +1,59 @@
+from collections.abc import Callable
+from functools import partial
+
+import jax.numpy as jnp
+import jpu.numpy as jnpu
+
+from jaxoplanet import units
+from jaxoplanet.core.limb_dark import light_curve as _limb_dark_light_curve
+from jaxoplanet.light_curves.utils import vectorize
+from jaxoplanet.experimental.starry.orbit import SurfaceSystem
+from jaxoplanet.types import Array, Quantity
+from jaxoplanet.units import unit_registry as ureg
+
+
+def light_curve(system: SurfaceSystem, order: int = 10) -> Callable[[Quantity], Array]:
+
+    assert isinstance(
+        system, SurfaceSystem
+    ), f"Expected an instance of 'SurfaceSystem', but got {type(system)}"
+
+    @units.quantity_input(time=ureg.d)
+    @vectorize
+    def light_curve_impl(time: Quantity) -> Array:
+        if jnpu.ndim(time) != 0:
+            raise ValueError(
+                "The time passed to 'light_curve' has shape "
+                f"{jnpu.shape(time)}, but a scalar was expected; "
+                "this shouldn't typically happen so please open an issue "
+                "on GitHub demonstrating the problem"
+            )
+
+        # Evaluate the coordinates of the transiting body
+        r_star = system.central.radius
+        x, y, z = system.relative_position(time)
+
+        b = jnpu.sqrt(x**2 + y**2) / r_star
+        assert b.units == ureg.dimensionless
+        r = system.radius / r_star
+        assert r.units == ureg.dimensionless
+
+        lc_func = partial(_limb_dark_light_curve, system.central_surface.u, order=order)
+        lc = lc_func(b.magnitude, r.magnitude)
+        lc = jnp.where(z > 0, lc, 0.0).sum(0) + 1
+
+        bodies_lc = []
+        for body, surface in zip(system.bodies, system.body_surfaces):
+            x, y, z = body.relative_position(time)
+            b = jnpu.sqrt(x**2 + y**2) / body.radius
+            r = r_star / body.radius
+
+            lc_func = partial(_limb_dark_light_curve, surface.u, order=order)
+            lc_body = lc_func(b.magnitude, r.magnitude)
+            lc_body = surface.amplitude * (1 + jnp.where(z < 0, lc_body, 0))
+
+            bodies_lc.append(lc_body)
+
+        return jnp.hstack([lc, *bodies_lc])
+
+    return light_curve_impl

--- a/src/jaxoplanet/light_curves/emission.py
+++ b/src/jaxoplanet/light_curves/emission.py
@@ -6,8 +6,8 @@ import jpu.numpy as jnpu
 
 from jaxoplanet import units
 from jaxoplanet.core.limb_dark import light_curve as _limb_dark_light_curve
-from jaxoplanet.light_curves.utils import vectorize
 from jaxoplanet.experimental.starry.orbit import SurfaceSystem
+from jaxoplanet.light_curves.utils import vectorize
 from jaxoplanet.types import Array, Quantity
 from jaxoplanet.units import unit_registry as ureg
 
@@ -43,7 +43,7 @@ def light_curve(system: SurfaceSystem, order: int = 10) -> Callable[[Quantity], 
         lc = jnp.where(z > 0, lc, 0.0).sum(0) + 1
 
         bodies_lc = []
-        for body, surface in zip(system.bodies, system.body_surfaces):
+        for body, surface in zip(system.bodies, system.body_surfaces, strict=False):
             x, y, z = body.relative_position(time)
             b = jnpu.sqrt(x**2 + y**2) / body.radius
             r = r_star / body.radius

--- a/tests/experimental/starry/light_curve_test.py
+++ b/tests/experimental/starry/light_curve_test.py
@@ -546,7 +546,7 @@ def test_emission_light_curve(params):
     central = keplerian.Central(radius=params["r"][0], mass=0.5)
     system = SurfaceSystem(central, Surface(u=params["u"][0], amplitude=params["a"][0]))
 
-    for r, u, a in zip(params["r"][1:], params["u"][1:], params["a"][1:]):
+    for r, u, a in zip(params["r"][1:], params["u"][1:], params["a"][1:], strict=False):
         system = system.add_body(
             radius=r, surface=Surface(u=u, amplitude=a), period=1.0
         )


### PR DESCRIPTION
A light_curve function taking into account transit and occultations of emissive (optionally limb darkened) bodies.

This function takes a `SurfaceSystem` in so that the limb darkening and amplitude of each body is defined using the `Surface` object.

Example:
```python
import jax.numpy as jnp
import matplotlib.pyplot as plt
from jaxoplanet.orbits import keplerian
from jaxoplanet.experimental.starry.surface import Surface
from jaxoplanet.experimental.starry.orbit import SurfaceSystem
from jaxoplanet.light_curves.emission import light_curve

central = keplerian.Central()

system = SurfaceSystem(central, Surface(u=(0.1, 0.2), amplitude=1.0)).add_body(
    radius=0.5, period=1.0, surface=Surface(amplitude=0.5, normalize=False)
)

period = system.bodies[0].period.magnitude
time = jnp.linspace(-0.8 * period, 0.8 * period, 1000)
plt.plot(time, light_curve(system)(time).sum(1))
plt.xlabel("time (days)")
plt.ylabel("flux")
```

<img width="563" alt="Screenshot 2024-10-04 at 1 52 55 PM" src="https://github.com/user-attachments/assets/4e0e0fb0-6fab-4155-adb9-4474386eac72">
