### PR TITLE
feat: add multiprecision limb darkening light curves + precision estimates functions

### DIFF
--- a/src/jaxoplanet/experimental/starry/light_curves.py
+++ b/src/jaxoplanet/experimental/starry/light_curves.py
@@ -103,6 +103,7 @@ def surface_light_curve(
     z: float | None = None,
     theta: float = 0.0,
     order: int = 20,
+    higher_precision: bool = False,
 ):
     """Light curve of an occulted surface.
 
@@ -124,6 +125,17 @@ def surface_light_curve(
     Returns:
         ArrayLike: flux
     """
+    if higher_precision:
+        try:
+            from jaxoplanet.experimental.starry.multiprecision import (
+                basis as basis_mp,
+                utils as utils_mp,
+            )
+        except ImportError as e:
+            raise ImportError(
+                "The `mpmath` Python package is required for higher_precision=True."
+            ) from e
+
     rT_deg = rT(surface.deg)
 
     x = 0.0 if x is None else x
@@ -150,8 +162,11 @@ def surface_light_curve(
         sT = solution_vector(surface.deg, order=order)(b, r)
 
         if surface.deg > 0:
-            A2 = scipy.sparse.linalg.inv(A2_inv(surface.deg))
-            A2 = jax.experimental.sparse.BCOO.from_scipy_sparse(A2)
+            if higher_precision:
+                A2 = np.atleast_2d(utils_mp.to_numpy(basis_mp.A2(surface.deg)))
+            else:
+                A2 = scipy.sparse.linalg.inv(A2_inv(surface.deg))
+                A2 = jax.experimental.sparse.BCOO.from_scipy_sparse(A2)
         else:
             A2 = jnp.array([[1]])
 
@@ -177,7 +192,11 @@ def surface_light_curve(
         p_u = Pijk.from_dense(u @ U(surface.udeg), degree=surface.udeg)
 
     # surface map * limb darkening map
-    A1_val = jax.experimental.sparse.BCOO.from_scipy_sparse(A1(surface.ydeg))
+    if higher_precision:
+        A1_val = np.atleast_2d(utils_mp.to_numpy(basis_mp.A1(surface.ydeg)))
+    else:
+        A1_val = jax.experimental.sparse.BCOO.from_scipy_sparse(A1(surface.ydeg))
+
     p_y = Pijk.from_dense(A1_val @ rotated_y, degree=surface.ydeg)
     p_y = p_y * p_u
 

--- a/src/jaxoplanet/experimental/starry/multiprecision/flux.py
+++ b/src/jaxoplanet/experimental/starry/multiprecision/flux.py
@@ -1,6 +1,7 @@
 from collections import defaultdict
 
-from jaxoplanet.experimental.starry.multiprecision import mp
+from jaxoplanet.experimental.starry.basis import U
+from jaxoplanet.experimental.starry.multiprecision import mp, utils
 from jaxoplanet.experimental.starry.multiprecision.basis import A1, A2
 from jaxoplanet.experimental.starry.multiprecision.rotation import (
     dot_rotation_matrix,
@@ -8,9 +9,7 @@ from jaxoplanet.experimental.starry.multiprecision.rotation import (
     get_R,
 )
 from jaxoplanet.experimental.starry.multiprecision.solution import get_sT, rT
-from jaxoplanet.experimental.starry.multiprecision import utils
 from jaxoplanet.experimental.starry.pijk import Pijk
-from jaxoplanet.experimental.starry.basis import U
 
 CACHED_MATRICES = defaultdict(
     lambda: {

--- a/src/jaxoplanet/experimental/starry/multiprecision/flux.py
+++ b/src/jaxoplanet/experimental/starry/multiprecision/flux.py
@@ -9,15 +9,18 @@ from jaxoplanet.experimental.starry.multiprecision.rotation import (
 )
 from jaxoplanet.experimental.starry.multiprecision.solution import get_sT, rT
 
+CACHED_MATRICES = defaultdict(
+    lambda: {
+        "R_obl": {},
+        "R_inc": {},
+        "sT": {},
+    }
+)
+
 
 def flux_function(l_max, inc, obl, cache=None):
     if cache is None:
-        cache = defaultdict(
-            lambda: {
-                "R_obl": {},
-                "R_inc": {},
-            }
-        )
+        cache = CACHED_MATRICES
 
     _rT = rT(l_max)
     _A1 = A1(l_max, cache=cache)
@@ -46,7 +49,7 @@ def flux_function(l_max, inc, obl, cache=None):
         xo = 0.0
         yo = b
         theta_z = mp.atan2(xo, yo)
-        _sT = get_sT(l_max, b, r)
+        _sT = get_sT(l_max, b, r, cache=cache)
         x = _sT.T @ _A2
         if rotate:
             y_rotated = rotate_y(y, phi)

--- a/src/jaxoplanet/experimental/starry/multiprecision/flux.py
+++ b/src/jaxoplanet/experimental/starry/multiprecision/flux.py
@@ -8,6 +8,9 @@ from jaxoplanet.experimental.starry.multiprecision.rotation import (
     get_R,
 )
 from jaxoplanet.experimental.starry.multiprecision.solution import get_sT, rT
+from jaxoplanet.experimental.starry.multiprecision import utils
+from jaxoplanet.experimental.starry.pijk import Pijk
+from jaxoplanet.experimental.starry.basis import U
 
 CACHED_MATRICES = defaultdict(
     lambda: {
@@ -18,25 +21,33 @@ CACHED_MATRICES = defaultdict(
 )
 
 
-def flux_function(l_max, inc, obl, cache=None):
+def flux(ydeg=0, udeg=0, inc=mp.pi / 2, obl=0.0, cache=None):
     if cache is None:
         cache = CACHED_MATRICES
 
-    _rT = rT(l_max)
-    _A1 = A1(l_max, cache=cache)
-    _A2 = A2(l_max, cache=cache)
+    deg = ydeg + udeg
 
-    R_px = get_R("R_px", l_max, cache=cache)
-    R_mx = get_R("R_mx", l_max, cache=cache)
-    R_obl = get_R("R_obl", l_max, obl=obl, inc=inc, cache=cache)
-    R_inc = get_R("R_inc", l_max, obl=obl, inc=inc, cache=cache)
+    _rT = rT(deg)
+    _A2 = A2(deg, cache=cache)
+
+    if ydeg > 0:
+        _A1 = A1(ydeg, cache=cache)
+        R_px = get_R("R_px", ydeg, cache=cache)
+        R_mx = get_R("R_mx", ydeg, cache=cache)
+        R_obl = get_R("R_obl", ydeg, obl=obl, inc=inc, cache=cache)
+        R_inc = get_R("R_inc", ydeg, obl=obl, inc=inc, cache=cache)
+    else:
+        _A1 = A1(0, cache=cache)
+
+    if udeg > 0:
+        rT_udeg = rT(udeg)
 
     def rotate_y(y, phi):
-        y_rotated = dot_rotation_matrix(l_max, None, None, R_px)(y)
-        y_rotated = dot_rz(l_max, phi)(y_rotated)
-        y_rotated = dot_rotation_matrix(l_max, None, None, R_mx)(y_rotated)
-        y_rotated = dot_rotation_matrix(l_max, None, None, R_obl)(y_rotated)
-        y_rotated = dot_rotation_matrix(l_max, None, None, R_inc)(y_rotated)
+        y_rotated = dot_rotation_matrix(ydeg, None, None, R_px)(y)
+        y_rotated = dot_rz(ydeg, phi)(y_rotated)
+        y_rotated = dot_rotation_matrix(ydeg, None, None, R_mx)(y_rotated)
+        y_rotated = dot_rotation_matrix(ydeg, None, None, R_obl)(y_rotated)
+        y_rotated = dot_rotation_matrix(ydeg, None, None, R_inc)(y_rotated)
         return y_rotated
 
     def rot_flux(y, phi):
@@ -44,27 +55,46 @@ def flux_function(l_max, inc, obl, cache=None):
         y_rotated = rotate_y(y, phi, cache=cache)
         return ((_A1 @ y_rotated).T @ _rT)[0]
 
-    def occ_flux(y, b, r, phi, rotate=True):
-        y = mp.matrix(y.tolist())
+    def occ_flux(y, b, r, phi=0.0, u=None, rotate=True):
         xo = 0.0
         yo = b
         theta_z = mp.atan2(xo, yo)
-        _sT = get_sT(l_max, b, r, cache=cache)
+        _sT = get_sT(deg, b, r, cache=cache)
         x = _sT.T @ _A2
-        if rotate:
-            y_rotated = rotate_y(y, phi)
-            y_rotated = dot_rz(l_max, theta_z)(y_rotated)
-        else:
-            y_rotated = y
-        py = (_A1 @ y_rotated).T
-        return py @ x.T
 
-    def impl(y, b, r, phi, rotate=True):
+        if ydeg > 0:
+            y = mp.matrix(y.tolist())
+            if rotate:
+                y_rotated = rotate_y(y, phi)
+                y_rotated = dot_rz(ydeg, theta_z)(y_rotated)
+        else:
+            y_rotated = mp.matrix([1])
+
+        py = (_A1 @ y_rotated).T
+
+        if udeg > 0:
+            _U = utils.to_mp(U(udeg))
+            u = mp.matrix([1, *u])
+            pu = u.T @ _U
+            norm = mp.pi / (pu @ rT_udeg)[0]
+            py = Pijk.from_dense(pu.tolist()[0]) * Pijk.from_dense(py)
+            py = mp.matrix(
+                [py.data.get(Pijk.n2ijk(i), 0.0) for i in range((py.degree + 1) ** 2)]
+            ).T
+        else:
+            norm = 1
+        return norm * py @ x.T
+
+    def impl(b, r, y=(), phi=0.0, u=(), rotate=True):
+        assert len(u) == udeg, "u must have length udeg"
+        if ydeg > 0:
+            assert len(y) == (ydeg + 1) ** 2, "y must have length (ydeg + 1) ** 2"
+
         if abs(b) >= (r + 1):
             return rot_flux(y, phi)
         elif r > 1 and abs(b) <= (r - 1):
             return mp.mpf(0.0)
         else:
-            return occ_flux(y, b, r, phi, rotate=rotate)[0]
+            return occ_flux(y, b, r, phi, u=u, rotate=rotate)[0]
 
     return impl

--- a/src/jaxoplanet/experimental/starry/multiprecision/precision.py
+++ b/src/jaxoplanet/experimental/starry/multiprecision/precision.py
@@ -25,7 +25,7 @@ def starry_light_curve(
     u = [1.0] * udeg
     y = np.ones((ydeg + 1) ** 2)
     surface = Surface(y=Ylm.from_dense(y), u=u, normalize=False)
-    expected = flux.flux.flux(ydeg=ydeg, udeg=udeg)(b, r, u=u, y=y)
+    expected = flux.flux(ydeg=ydeg, udeg=udeg)(b, r, u=u, y=y)
     calc = surface_light_curve(surface, y=b, z=1.0, r=r, order=order)
     return float(np.abs(float(mp.mpf(float(calc)) - expected)))
 
@@ -47,6 +47,6 @@ def limb_dark_light_curve(
     if b is None:
         b = 1 - r if r < 1.0 else r
     u = [1.0] * udeg
-    expected = flux.flux.flux(udeg=udeg)(b, r, u=u)
+    expected = flux.flux(udeg=udeg)(b, r, u=u)
     calc = 1 + ld_light_curve(u, b, r, order=order)
     return np.abs(float(mp.mpf(float(calc)) - expected))

--- a/src/jaxoplanet/experimental/starry/multiprecision/precision.py
+++ b/src/jaxoplanet/experimental/starry/multiprecision/precision.py
@@ -1,8 +1,9 @@
+import numpy as np
+
+from jaxoplanet.core.limb_dark import light_curve as ld_light_curve
 from jaxoplanet.experimental.starry import Surface, Ylm
 from jaxoplanet.experimental.starry.light_curves import surface_light_curve
-from jaxoplanet.core.limb_dark import light_curve as ld_light_curve
 from jaxoplanet.experimental.starry.multiprecision import flux, mp
-import numpy as np
 
 
 def starry_light_curve(

--- a/src/jaxoplanet/experimental/starry/multiprecision/precision.py
+++ b/src/jaxoplanet/experimental/starry/multiprecision/precision.py
@@ -1,0 +1,52 @@
+from jaxoplanet.experimental.starry import Surface, Ylm
+from jaxoplanet.experimental.starry.light_curves import surface_light_curve
+from jaxoplanet.core.limb_dark import light_curve as ld_light_curve
+from jaxoplanet.experimental.starry.multiprecision import flux, mp
+import numpy as np
+
+
+def starry_light_curve(
+    ydeg: int, udeg: int, r: float, order: int, b: float | None = None
+) -> float:
+    """Estimate the absolute precision of a starry light curve.
+
+    Args:
+        ydeg (int): Degree of the spherical harmonics map.
+        udeg (int): Order of the limb darkening polynomial.
+        r (float): Radius ratio.
+        order (int): Numerical integration order.
+        b (float, optional): Impact parameter. Defaults to None.
+
+    Returns:
+        float: Precision of the jaxoplanet light curve model.
+    """
+    if b is None:
+        b = 1 - r if r < 1.0 else r
+    u = [1.0] * udeg
+    y = np.ones((ydeg + 1) ** 2)
+    surface = Surface(y=Ylm.from_dense(y), u=u, normalize=False)
+    expected = flux.flux.flux(ydeg=ydeg, udeg=udeg)(b, r, u=u, y=y)
+    calc = surface_light_curve(surface, y=b, z=1.0, r=r, order=order)
+    return float(np.abs(float(mp.mpf(float(calc)) - expected)))
+
+
+def limb_dark_light_curve(
+    udeg: int, r: float, order: int, b: float | None = None
+) -> float:
+    """Estimate the absolute precision of a limb darkened star light curve.
+
+    Args:
+        udeg (int): Order of the limb darkening polynomial.
+        r (float): Radius ratio.
+        order (int): Numerical integration order.
+        b (float | None, optional): Impact parameter. Defaults to None.
+
+    Returns:
+        float: Precision of the jaxoplanet light curve model.
+    """
+    if b is None:
+        b = 1 - r if r < 1.0 else r
+    u = [1.0] * udeg
+    expected = flux.flux.flux(udeg=udeg)(b, r, u=u)
+    calc = 1 + ld_light_curve(u, b, r, order=order)
+    return np.abs(float(mp.mpf(float(calc)) - expected))

--- a/src/jaxoplanet/experimental/starry/rotation.py
+++ b/src/jaxoplanet/experimental/starry/rotation.py
@@ -4,6 +4,9 @@ from functools import partial
 import jax
 import jax.numpy as jnp
 
+from jaxoplanet.experimental.starry.s2fft_rotation import (
+    compute_rotation_matrices as compute_rotation_matrices_s2fft,
+)
 from jaxoplanet.types import Array
 from jaxoplanet.utils import get_dtype_eps
 
@@ -42,7 +45,7 @@ def dot_rotation_matrix(ydeg, x, y, z, theta):
     if jnp.shape(theta) != ():
         raise ValueError(f"theta must be a scalar; got {jnp.shape(theta)}")
 
-    rotation_matrices = compute_rotation_matrices(ydeg, x, y, z, theta)
+    rotation_matrices = compute_rotation_matrices_s2fft(ydeg, x, y, z, theta)
     n_max = ydeg**2 + 2 * ydeg + 1
 
     @jax.jit
@@ -95,14 +98,18 @@ def full_rotation_axis_angle(inc: float, obl: float, theta: float, theta_z: floa
     arg = si * cm + ci * cp
     denominator = jnp.sqrt(1 - 0.5 * arg**2)
 
-    angle = 2 * jnp.arccos(f * arg)
+    farg = f * arg
+    zero_angle = jnp.allclose(farg, 1.0, atol=get_dtype_eps(farg))
+    angle = jnp.where(zero_angle, 0.0, 2 * jnp.arccos(farg))
+
+    non_zero_angle = jnp.logical_not(zero_angle)
 
     # this is mostly useful for the float32 case, where
     # (1 - 0.5 * arg**2) in denominator can be negative due to numerical error
     positive_arg = arg**2 < 2.0
-    axis_x = jnp.where(positive_arg, numerator1 / denominator, 1.0)
-    axis_y = jnp.where(positive_arg, numerator2 / denominator, 0.0)
-    axis_z = jnp.where(positive_arg, numerator3 / denominator, 0.0)
+    axis_x = jnp.where(positive_arg & non_zero_angle, numerator1 / denominator, 1.0)
+    axis_y = jnp.where(positive_arg & non_zero_angle, numerator2 / denominator, 0.0)
+    axis_z = jnp.where(positive_arg & non_zero_angle, numerator3 / denominator, 0.0)
 
     return axis_x, axis_y, axis_z, angle
 
@@ -124,6 +131,9 @@ def sky_projection_axis_angle(inc: float, obl: float):
     si = jnp.sin(inc / 2)
 
     denominator = jnp.sqrt(1 - ci**2 * co**2)
+
+    # to avoid nans for the case where ci * co == 1
+    denominator = jnp.where(denominator == 0.0, 1.0, denominator)
 
     axis_x = si * co
     axis_y = si * so

--- a/src/jaxoplanet/experimental/starry/s2fft_rotation.py
+++ b/src/jaxoplanet/experimental/starry/s2fft_rotation.py
@@ -1,0 +1,194 @@
+"""Some of the code in this submodule is taken directly from the MIT-licensed
+'s2fft' package. Below is the original license text:
+
+Copyright (c) 2022 Authors & Contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+"""
+
+import jax.numpy as jnp
+from jax.scipy.spatial.transform import Rotation
+
+
+def _compute_full(dl: jnp.ndarray, beta: float, L: int, el: int) -> jnp.ndarray:
+    """from s2fft.recursions.risbo_jax"""
+
+    if el == 0:
+        dl = dl.at[el + L - 1, el + L - 1].set(1.0)
+        return dl
+    if el == 1:
+        cosb = jnp.cos(beta)
+        sinb = jnp.sin(beta)
+
+        coshb = jnp.cos(beta / 2.0)
+        sinhb = jnp.sin(beta / 2.0)
+        sqrt2 = jnp.sqrt(2.0)
+
+        dl = dl.at[L - 2, L - 2].set(coshb**2)
+        dl = dl.at[L - 2, L - 1].set(sinb / sqrt2)
+        dl = dl.at[L - 2, L].set(sinhb**2)
+
+        dl = dl.at[L - 1, L - 2].set(-sinb / sqrt2)
+        dl = dl.at[L - 1, L - 1].set(cosb)
+        dl = dl.at[L - 1, L].set(sinb / sqrt2)
+
+        dl = dl.at[L, L - 2].set(sinhb**2)
+        dl = dl.at[L, L - 1].set(-sinb / sqrt2)
+        dl = dl.at[L, L].set(coshb**2)
+        return dl
+    else:
+        coshb = -jnp.cos(beta / 2.0)
+        sinhb = jnp.sin(beta / 2.0)
+        dd = jnp.zeros((2 * el + 2, 2 * el + 2))
+
+        # First pass
+        j = 2 * el - 1
+        i = jnp.arange(j)
+        k = jnp.arange(j)
+
+        sqrt_jmk = jnp.sqrt(j - k)
+        sqrt_kp1 = jnp.sqrt(k + 1)
+        sqrt_jmi = jnp.sqrt(j - i)
+        sqrt_ip1 = jnp.sqrt(i + 1)
+
+        dlj = dl[k - (el - 1) + L - 1][:, i - (el - 1) + L - 1]
+
+        dd = dd.at[:j, :j].add(
+            jnp.einsum("i,k->ki", sqrt_jmi, sqrt_jmk, optimize=True) * dlj * coshb
+        )
+        dd = dd.at[:j, 1 : j + 1].add(
+            jnp.einsum("i,k->ki", -sqrt_ip1, sqrt_jmk, optimize=True) * dlj * sinhb
+        )
+        dd = dd.at[1 : j + 1, :j].add(
+            jnp.einsum("i,k->ki", sqrt_jmi, sqrt_kp1, optimize=True) * dlj * sinhb
+        )
+        dd = dd.at[1 : j + 1, 1 : j + 1].add(
+            jnp.einsum("i,k->ki", sqrt_ip1, sqrt_kp1, optimize=True) * dlj * coshb
+        )
+
+        dl = dl.at[-el + L - 1 : el + 1 + L - 1, -el + L - 1 : el + 1 + L - 1].multiply(
+            0.0
+        )
+
+        j = 2 * el
+        i = jnp.arange(j)
+        k = jnp.arange(j)
+
+        # Second pass
+        sqrt_jmk = jnp.sqrt(j - k)
+        sqrt_kp1 = jnp.sqrt(k + 1)
+        sqrt_jmi = jnp.sqrt(j - i)
+        sqrt_ip1 = jnp.sqrt(i + 1)
+
+        dl = dl.at[-el + L - 1 : el + L - 1, -el + L - 1 : el + L - 1].add(
+            jnp.einsum("i,k->ki", sqrt_jmi, sqrt_jmk, optimize=True)
+            * dd[:j, :j]
+            * coshb,
+        )
+        dl = dl.at[-el + L - 1 : el + L - 1, L - el : L + el].add(
+            jnp.einsum("i,k->ki", -sqrt_ip1, sqrt_jmk, optimize=True)
+            * dd[:j, :j]
+            * sinhb,
+        )
+        dl = dl.at[L - el : L + el, -el + L - 1 : el + L - 1].add(
+            jnp.einsum("i,k->ki", sqrt_jmi, sqrt_kp1, optimize=True)
+            * dd[:j, :j]
+            * sinhb,
+        )
+        dl = dl.at[L - el : L + el, L - el : L + el].add(
+            jnp.einsum("i,k->ki", sqrt_ip1, sqrt_kp1, optimize=True)
+            * dd[:j, :j]
+            * coshb,
+        )
+        return dl / ((2 * el) * (2 * el - 1))
+
+
+def _generate_rotate_dls(L: int, beta: float) -> jnp.ndarray:
+    """*from s2fft.utils*"""
+    dl = jnp.zeros((L, 2 * L - 1, 2 * L - 1)).astype(float)
+    dl_iter = jnp.zeros((2 * L - 1, 2 * L - 1)).astype(float)
+    for el in range(L):
+        dl_iter = _compute_full(dl_iter, beta, L, el)
+        dl = dl.at[el].add(dl_iter)
+    return dl
+
+
+def compute_rotation_matrices(deg, x, y, z, theta, homogeneous=False):
+
+    def kron(m, n):
+        """Kronecker delta. Can we do better?"""
+        return m == n
+
+    def Umn(m, n):
+        """Compute the (m, n) term of the transformation
+        matrix from complex to real Ylms. This part is from starry"""
+        if n < 0:
+            term1 = 1j
+        elif n == 0:
+            term1 = jnp.sqrt(2) / 2
+        else:
+            term1 = 1
+        if (m > 0) and (n < 0) and (n % 2 == 0):
+            term2 = -1
+        elif (m > 0) and (n > 0) and (n % 2 != 0):
+            term2 = -1
+        else:
+            term2 = 1
+        return term1 * term2 * 1 / jnp.sqrt(2) * (kron(m, n) + kron(m, -n) + 0j)
+
+    def U(l):
+        """Compute the complete U transformation matrix.. This part is from starry"""
+        res = jnp.zeros((2 * l + 1, 2 * l + 1)) + 0j
+        for m in range(-l, l + 1):
+            for n in range(-l, l + 1):
+                res = res.at[m + l, n + l].set(Umn(m, n))
+        return res
+
+    def euler(x, y, z, theta):
+        """axis-angle to euler angles"""
+        # the jnp where for theta == 0 is to avoid nans when computing grad
+        axis = jnp.array([jnp.where(theta == 0.0, 1.0, x), y, z])
+        _theta = jnp.where(theta == 0.0, 1.0, theta)
+        axis = axis / jnp.linalg.norm(axis)
+        r = Rotation.from_rotvec(axis * _theta)
+        return jnp.where(theta == 0.0, jnp.array([0.0, 0.0, 0.0]), r.as_euler("zyz"))
+
+    alpha, beta, gamma = euler(x, y, z, theta)
+    dls = _generate_rotate_dls(deg + 1, beta)
+    N = jnp.arange(-deg, deg + 1)
+    m, mp = jnp.meshgrid(N, N)
+    Dlm = jnp.exp(-1j * (m * alpha + mp * gamma)) * dls
+
+    u = U(deg)
+    u_inv = jnp.conj(u.T)
+
+    # The output of generate_rotate_dls has shape (L, 2L+1, 2L+1)
+    Rs_full = jnp.real(u_inv[None, :] @ Dlm @ u[None, :])
+
+    if homogeneous:
+        Rs = Rs_full
+    else:
+        # reformat to a list of matrices with different shape
+        # (to match current implementation of rotation.dot_rotation_matrix)
+        Rs = []
+
+        for i in range(deg + 1):
+            Rs.append(Rs_full[i, deg - i : deg + i + 1, deg - i : deg + i + 1])
+
+    return Rs

--- a/tests/experimental/starry/light_curve_test.py
+++ b/tests/experimental/starry/light_curve_test.py
@@ -49,7 +49,6 @@ def test_compare_starry_limb_dark(deg, u):
 @pytest.mark.parametrize("r", [0.01, 0.1, 1.0, 10.0, 100.0])
 def test_flux(r, l_max=5, order=500):
     pytest.importorskip("mpmath")
-    from jaxoplanet.experimental.starry.multiprecision import mp
 
     # We know that these are were the errors are the highest
     b = 1 - r if r < 1 else r

--- a/tests/experimental/starry/light_curve_test.py
+++ b/tests/experimental/starry/light_curve_test.py
@@ -4,6 +4,7 @@ import pytest
 
 from jaxoplanet.experimental.starry import Surface, Ylm
 from jaxoplanet.experimental.starry.light_curves import light_curve, surface_light_curve
+from jaxoplanet.experimental.starry.multiprecision import flux as mp_flux
 from jaxoplanet.experimental.starry.orbit import SurfaceSystem
 from jaxoplanet.light_curves import limb_dark_light_curve
 from jaxoplanet.light_curves.emission import light_curve as emission_light_curve
@@ -48,7 +49,7 @@ def test_compare_starry_limb_dark(deg, u):
 @pytest.mark.parametrize("r", [0.01, 0.1, 1.0, 10.0, 100.0])
 def test_flux(r, l_max=5, order=500):
     pytest.importorskip("mpmath")
-    from jaxoplanet.experimental.starry.multiprecision import flux as mp_flux, mp
+    from jaxoplanet.experimental.starry.multiprecision import mp
 
     # We know that these are were the errors are the highest
     b = 1 - r if r < 1 else r
@@ -65,7 +66,7 @@ def test_flux(r, l_max=5, order=500):
         return surface_light_curve(surface, y=b, z=10.0, r=r, order=order)
 
     for i, y in enumerate(ys):
-        expect[i] = float(mp_flux.flux_function(l_max, mp.pi / 2, 0.0)(y, b, r, 0.0))
+        expect[i] = float(mp_flux.flux(ydeg=l_max)(b, r, y=y))
         calc[i] = light_curve(y)
 
     for n in range(expect.size):


### PR DESCRIPTION
> [!IMPORTANT]
> #212 should be merged first


The idea of this PR is to provide users with functions to estimate the light curve precision based on their setup.

For example:
```python
from jaxoplanet.experimental.starry.multiprecision import precision 

# starry_light_curve(ydeg, ugdeg, r, order)
precision.starry_light_curve(3, 2, 0.1, 15)

# limb_dark_light_curve(udeg, r, order)
precision.limb_dark_light_curve(2, 0.1, 10)
```