### PR TITLE
fix: attempt for comparison test ci

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,7 +26,7 @@ jobs:
           - os: "macos-latest"
             python-version: "3.11"
             session: "test"
-          - os: "ubuntu-latest"
+          - os: "ubuntu-22.04"
             python-version: "3.10"
             session: "comparison"
 


### PR DESCRIPTION
Comparison tests failed potentially due to https://github.com/actions/runner-images/issues/10636. Fixing by downgrading ubuntu-latest to ubuntu-22.04. Thanks @lgarrison 🙏🏼