### PR TITLE
feat: add power2 light curve

### DIFF
--- a/src/jaxoplanet/core/power_two.py
+++ b/src/jaxoplanet/core/power_two.py
@@ -1,0 +1,70 @@
+from functools import partial
+
+import jax
+import jax.numpy as jnp
+
+
+@partial(jax.jit, static_argnames=("eps",))
+def light_curve(c, alpha, b, r, eps=1e-12):
+    I_0 = (alpha + 2) / (jnp.pi * (alpha - c * alpha + 2))
+    g = 0.5 * alpha
+    b = jnp.abs(b)
+    r = jnp.abs(r)
+
+    def q1(z, p, c, alpha):
+        zt = jnp.clip(abs(z), 0, 1 - p)
+        s = 1 - zt**2
+        c0 = 1 - c + c * s**g
+        c2 = 0.5 * alpha * c * s ** (g - 2) * ((alpha - 1) * zt**2 - 1)
+        return 1 - I_0 * jnp.pi * p**2 * (
+            c0 + 0.25 * p**2 * c2 - 0.125 * alpha * c * p**2 * s ** (g - 1)
+        )
+
+    def q2(z, p, c, alpha):
+        zt = jnp.clip(abs(z), 1 - p, 1 + p)
+        d = jnp.clip((zt**2 - p**2 + 1) / (2 * zt), 0, 1)
+        ra = 0.5 * (zt - p + d)
+        rb = 0.5 * (1 + d)
+        sa = jnp.clip(1 - ra**2, eps, 1)
+        sb = jnp.clip(1 - rb**2, eps, 1)
+        q = jnp.clip((zt - d) / p, -1, 1)
+        w2 = p**2 - (d - zt) ** 2
+        w = jnp.sqrt(jnp.clip(w2, eps, 1))
+        b0 = 1 - c + c * sa**g
+        b1 = -alpha * c * ra * sa ** (g - 1)
+        b2 = 0.5 * alpha * c * sa ** (g - 2) * ((alpha - 1) * ra**2 - 1)
+        a0 = b0 + b1 * (zt - ra) + b2 * (zt - ra) ** 2
+        a1 = b1 + 2 * b2 * (zt - ra)
+        aq = jnp.arccos(q)
+        J1 = (
+            a0 * (d - zt)
+            - (2 / 3) * a1 * w2
+            + 0.25 * b2 * (d - zt) * (2 * (d - zt) ** 2 - p**2)
+        ) * w + (a0 * p**2 + 0.25 * b2 * p**4) * aq
+        J2 = (
+            alpha
+            * c
+            * sa ** (g - 1)
+            * p**4
+            * (
+                0.125 * aq
+                + (1 / 12) * q * (q**2 - 2.5) * jnp.sqrt(jnp.clip(1 - q**2, 0, 1))
+            )
+        )
+        d0 = 1 - c + c * sb**g
+        d1 = -alpha * c * rb * sb ** (g - 1)
+        K1 = (d0 - rb * d1) * jnp.arccos(d) + (
+            (rb * d + (2 / 3) * (1 - d**2)) * d1 - d * d0
+        ) * jnp.sqrt(jnp.clip(1 - d**2, 0, 1))
+
+        K2 = (1 / 3) * c * alpha * sb ** (g + 0.5) * (1 - d)
+        return 1 - I_0 * (J1 - J2 + K1 - K2)
+
+    return (
+        jnp.select(
+            [b <= (1 - r), abs(b - 1) < r],
+            [q1(b, r, c, alpha), q2(b, r, c, alpha)],
+            default=1,
+        )
+        - 1.0
+    )

--- a/src/jaxoplanet/light_curves/__init__.py
+++ b/src/jaxoplanet/light_curves/__init__.py
@@ -1,4 +1,4 @@
-__all__ = ["transforms", "limb_dark_light_curve"]
+__all__ = ["transforms", "limb_dark_light_curve", "power_two_light_curve"]
 
 from jaxoplanet.light_curves import transforms as transforms
 from jaxoplanet.light_curves.limb_dark import light_curve as limb_dark_light_curve

--- a/src/jaxoplanet/light_curves/__init__.py
+++ b/src/jaxoplanet/light_curves/__init__.py
@@ -2,3 +2,4 @@ __all__ = ["transforms", "limb_dark_light_curve"]
 
 from jaxoplanet.light_curves import transforms as transforms
 from jaxoplanet.light_curves.limb_dark import light_curve as limb_dark_light_curve
+from jaxoplanet.light_curves.power_two import light_curve as power_two_light_curve

--- a/src/jaxoplanet/light_curves/power_two.py
+++ b/src/jaxoplanet/light_curves/power_two.py
@@ -1,0 +1,46 @@
+__all__ = ["light_curve"]
+
+from collections.abc import Callable
+from functools import partial
+
+import jax.numpy as jnp
+import jpu.numpy as jnpu
+
+from jaxoplanet import units
+from jaxoplanet.core.power_two import light_curve as _power_two_light_curve
+from jaxoplanet.light_curves.utils import vectorize
+from jaxoplanet.proto import LightCurveOrbit
+from jaxoplanet.types import Array, Quantity
+from jaxoplanet.units import unit_registry as ureg
+
+
+def light_curve(
+    orbit: LightCurveOrbit, alpha: Array, c: Array, eps: float = 1e-12
+) -> Callable[[Quantity], Array]:
+    @units.quantity_input(time=ureg.d)
+    @vectorize
+    def light_curve_impl(time: Quantity) -> Array:
+        if jnpu.ndim(time) != 0:
+            raise ValueError(
+                "The time passed to 'light_curve' has shape "
+                f"{jnpu.shape(time)}, but a scalar was expected; "
+                "this shouldn't typically happen so please open an issue "
+                "on GitHub demonstrating the problem"
+            )
+
+        # Evaluate the coordinates of the transiting body
+        r_star = orbit.central_radius
+        x, y, z = orbit.relative_position(time)
+
+        b = jnpu.sqrt(x**2 + y**2) / r_star
+        assert b.units == ureg.dimensionless
+        r = orbit.radius / r_star
+        assert r.units == ureg.dimensionless
+
+        lc_func = partial(_power_two_light_curve, alpha, c, eps=eps)
+        lc = lc_func(b.magnitude, r.magnitude)
+        lc = jnp.where(z > 0, lc, 0)
+
+        return lc
+
+    return light_curve_impl


### PR DESCRIPTION
As suggested by #264; adds a light curve model with the power-2 limb-darkening law.

For now comparison with pytransit fails (see below). I haven't tried to debug at all but some help would be great!
```python
import jax

jax.config.update("jax_enable_x64", True)

import numpy as np
from jaxoplanet.orbits.keplerian import System
from jaxoplanet.light_curves import limb_dark_light_curve, power_two_light_curve
import matplotlib.pyplot as plt
from pytransit import RRModel

time = np.linspace(-0.1, 0.1, 1000)

tm = RRModel("power-2")
tm.set_data(time=time)

radius = 0.2
system = System().add_body(period=1.0, radius=radius)

coeff = (0.4, 1.0)
expected = tm.evaluate(
    k=radius,
    ldc=coeff,
    t0=0.0,
    p=system.bodies[0].period.magnitude,
    a=system.bodies[0].semimajor.magnitude,
    i=np.pi / 2,
)

calc = power_two_light_curve(system, *coeff, eps=1e-15)(time).T[0] + 1.0

plt.subplot(121)
plt.plot(time, expected, label="pytransit")
plt.plot(time, calc, label="jaxoplanet")
plt.legend()
plt.xlabel("time")
plt.ylabel("flux")

plt.subplot(122)
plt.plot(time, expected - calc)
plt.xlabel("time")
plt.ylabel("error")
plt.tight_layout()
```
<img width="622" alt="Screenshot 2025-04-01 at 12 38 15 PM" src="https://github.com/user-attachments/assets/52b37a74-7ebf-44c6-ab4b-1f0036ad42a0" />

Suggested steps to reproduce the environment ([uv](https://github.com/astral-sh/uv) required):
```
git clone -b power2 https://github.com/exoplanet-dev/jaxoplanet.git
cd jaxoplanet
uv sync --extras dev
uv pip install pytransit # pytransit for comparison
source .venv/bin/activate
```

@saigrain, do you know what precision is expected from `pytransit`?