### PR TITLE
Reverting to custom vectorize decorator

### DIFF
--- a/src/jaxoplanet/light_curves/limb_dark.py
+++ b/src/jaxoplanet/light_curves/limb_dark.py
@@ -7,6 +7,7 @@ import jax
 import jax.numpy as jnp
 
 from jaxoplanet.core.limb_dark import light_curve as _limb_dark_light_curve
+from jaxoplanet.light_curves.utils import vectorize
 from jaxoplanet.proto import LightCurveOrbit
 from jaxoplanet.types import Array, Scalar
 
@@ -35,6 +36,7 @@ def light_curve(
     else:
         ld_u = jnp.array([])
 
+    @vectorize
     def light_curve_impl(time: Scalar) -> Array:
         if jnp.ndim(time) != 0:
             raise ValueError(
@@ -57,4 +59,4 @@ def light_curve(
 
         return lc
 
-    return jax.vmap(light_curve_impl)
+    return jax.jit(light_curve_impl)


### PR DESCRIPTION
@dfm and I discussed a change made in PR #262 that removed the `@vectorize` decorator and replaced it by vmapping the `light_curve_impl` closure function. An unintended result of that change was that the function returned from `limb_dark.light_curve` could only handle the time argument as arrays but not (single) scalar values (i.e., you wouldn't be able to calculate the flux at a single time value unless you made the time value into a 1D array). 

This PR reverts to using the custom `@vectorize` wrapper (which is a slightly modified `jax.numpy.vectorize`) so that it automatically handles both single time values and arrays.

I've also jitted the returned function. @dfm: This seems like a benign change but are there reasons not to jit at this level? 