### PR TITLE
Fix/issue #268

### DIFF
--- a/src/jaxoplanet/starry/light_curves.py
+++ b/src/jaxoplanet/starry/light_curves.py
@@ -91,7 +91,7 @@ def surface_light_curve(
 
             lc_func = partial(_limb_dark_light_curve, ld_u, order=order)
             lc = lc_func(b, r)
-            return 1.0 + jnp.where(b_occ, lc, 0)
+            return surface.amplitude * (1.0 + jnp.where(b_occ, lc, 0))
 
         else:
             theta_z = jnp.arctan2(x, y)

--- a/src/jaxoplanet/starry/system_observable.py
+++ b/src/jaxoplanet/starry/system_observable.py
@@ -38,7 +38,7 @@ def system_observable(surface_observable, **kwargs):
                 )
 
         @partial(jnp.vectorize, signature="()->(n)")
-        def obsrvable_impl(time: Scalar) -> Array:
+        def observable_impl(time: Scalar) -> Array:
             # a function that give the array of observables for all bodies, starting
             # with the central
             if system.central_surface is None:
@@ -46,7 +46,7 @@ def system_observable(surface_observable, **kwargs):
             else:
                 theta = system.central_surface.rotational_phase(time)
                 central_radius = system.central.radius
-                central_phase_curve = surface_observable(
+                central_phase_curve = _surface_observable(
                     system.central_surface, theta=theta
                 )
                 if len(system.bodies) > 0:
@@ -75,6 +75,6 @@ def system_observable(surface_observable, **kwargs):
                 else:
                     return jnp.array([central_phase_curve])
 
-        return obsrvable_impl
+        return observable_impl
 
     return observable_fun

--- a/tests/starry/light_curve_test.py
+++ b/tests/starry/light_curve_test.py
@@ -324,7 +324,6 @@ def test_compare_starry_rot(deg):
     assert_allclose(calc, expected)
 
 
-@pytest.mark.xfail(reason="see issue #268")
 def test_EB():
 
     params = {


### PR DESCRIPTION
This PR fixes #268. The issue seemed to stem from a code block in the `starry/light_curves.py/surface_light_curve` function for when `surface.ydeg = 0`. In this case the function returned the flux without multiplying it by the `surface.amplitude` value:
https://github.com/exoplanet-dev/jaxoplanet/blob/a3d1b8ce1fb364cc2c30eb2b2c414126695497f9/src/jaxoplanet/starry/light_curves.py#L94

I've changed the above line to
```python
return surface.amplitude * (1.0 + jnp.where(b_occ, lc, 0))
```
and now the `test_EB` test should pass.


