### PR TITLE
Expose starry and starry.light_curves submodules to fix #280

### DIFF
--- a/src/jaxoplanet/__init__.py
+++ b/src/jaxoplanet/__init__.py
@@ -1,9 +1,10 @@
-__all__ = ["core", "light_curves", "orbits", "experimental"]
+__all__ = ["core", "light_curves", "orbits", "experimental", "starry"]
 
 from jaxoplanet import (
     core as core,
     experimental as experimental,
     light_curves as light_curves,
     orbits as orbits,
+    starry as starry,
 )
 from jaxoplanet.jaxoplanet_version import __version__ as __version__

--- a/src/jaxoplanet/starry/__init__.py
+++ b/src/jaxoplanet/starry/__init__.py
@@ -5,3 +5,4 @@ from jaxoplanet.starry.core.solution import (
 from jaxoplanet.starry.surface import Surface as Surface
 from jaxoplanet.starry.visualization import show_surface as show_surface
 from jaxoplanet.starry.ylm import Ylm as Ylm
+from jaxoplanet.starry import light_curves

--- a/src/jaxoplanet/starry/__init__.py
+++ b/src/jaxoplanet/starry/__init__.py
@@ -1,7 +1,8 @@
-from jaxoplanet.starry import doppler as doppler, light_curves
+from jaxoplanet.starry import doppler as doppler
 from jaxoplanet.starry.core.solution import (
     solution_vector as solution_vector,
 )
 from jaxoplanet.starry.surface import Surface as Surface
 from jaxoplanet.starry.visualization import show_surface as show_surface
 from jaxoplanet.starry.ylm import Ylm as Ylm
+from jaxoplanet.starry import light_curves as light_curves

--- a/src/jaxoplanet/starry/__init__.py
+++ b/src/jaxoplanet/starry/__init__.py
@@ -5,3 +5,4 @@ from jaxoplanet.starry.core.solution import (
 from jaxoplanet.starry.surface import Surface as Surface
 from jaxoplanet.starry.visualization import show_surface as show_surface
 from jaxoplanet.starry.ylm import Ylm as Ylm
+from jaxoplanet.starry import light_curves as light_curves

--- a/src/jaxoplanet/starry/__init__.py
+++ b/src/jaxoplanet/starry/__init__.py
@@ -5,4 +5,3 @@ from jaxoplanet.starry.core.solution import (
 from jaxoplanet.starry.surface import Surface as Surface
 from jaxoplanet.starry.visualization import show_surface as show_surface
 from jaxoplanet.starry.ylm import Ylm as Ylm
-from jaxoplanet.starry import light_curves as light_curves

--- a/src/jaxoplanet/starry/__init__.py
+++ b/src/jaxoplanet/starry/__init__.py
@@ -1,8 +1,7 @@
-from jaxoplanet.starry import doppler as doppler
+from jaxoplanet.starry import doppler as doppler, light_curves as light_curves
 from jaxoplanet.starry.core.solution import (
     solution_vector as solution_vector,
 )
 from jaxoplanet.starry.surface import Surface as Surface
 from jaxoplanet.starry.visualization import show_surface as show_surface
 from jaxoplanet.starry.ylm import Ylm as Ylm
-from jaxoplanet.starry import light_curves as light_curves

--- a/src/jaxoplanet/starry/__init__.py
+++ b/src/jaxoplanet/starry/__init__.py
@@ -1,8 +1,7 @@
-from jaxoplanet.starry import doppler as doppler
+from jaxoplanet.starry import doppler as doppler, light_curves
 from jaxoplanet.starry.core.solution import (
     solution_vector as solution_vector,
 )
 from jaxoplanet.starry.surface import Surface as Surface
 from jaxoplanet.starry.visualization import show_surface as show_surface
 from jaxoplanet.starry.ylm import Ylm as Ylm
-from jaxoplanet.starry import light_curves


### PR DESCRIPTION
This PR exposes the `starry` and the `starry.light_curves` submodules to fix #280.

The following should now work:
```python
import jaxoplanet as jxo

jxo.starry.light_curves.surface_light_curve()
```