### PR TITLE
fix overlapping graticule in multi-axes plot

### DIFF
--- a/src/jaxoplanet/starry/utils.py
+++ b/src/jaxoplanet/starry/utils.py
@@ -109,9 +109,15 @@ def graticule(
     white_contour=True,
     radius: float = 1.0,
     n=6,
+    ax=None,
     **kwargs,
 ):
     import matplotlib.pyplot as plt
+
+    if ax is None:
+        ax = plt.gca()
+        if ax is None:
+            ax = plt.subplot(111)
 
     kwargs.setdefault("c", kwargs.pop("color", "k"))
     kwargs.setdefault("lw", kwargs.pop("linewidth", 1))
@@ -120,16 +126,16 @@ def graticule(
     # plot lines
     lat, lon = lon_lat_lines(pts=pts, radius=radius, n=n)
     lat = rotate_lines(lat, inc, obl, theta)
-    plot_lines(lat, **kwargs)
+    plot_lines(lat, ax=ax, **kwargs)
     lon = rotate_lines(lon, inc, obl, theta)
-    plot_lines(lon, **kwargs)
+    plot_lines(lon, ax=ax, **kwargs)
     theta = np.linspace(0, 2 * np.pi, 2 * pts)
 
     # contour
     sqrt_radius = radius
-    plt.plot(sqrt_radius * np.cos(theta), sqrt_radius * np.sin(theta), **kwargs)
+    ax.plot(sqrt_radius * np.cos(theta), sqrt_radius * np.sin(theta), **kwargs)
     if white_contour:
-        plt.plot(sqrt_radius * np.cos(theta), sqrt_radius * np.sin(theta), c="w", lw=3)
+        ax.plot(sqrt_radius * np.cos(theta), sqrt_radius * np.sin(theta), c="w", lw=3)
 
 
 # s2fft have the same but this one is jitabel

--- a/src/jaxoplanet/starry/visualization.py
+++ b/src/jaxoplanet/starry/visualization.py
@@ -93,7 +93,7 @@ def show_surface(
             radius=radius,
             n=n,
             white_contour=white_contour,
-            ax=ax
+            ax=ax,
         )
     ax.set_xlim(-1.02, 1.02)
     ax.set_ylim(-1.02, 1.02)

--- a/src/jaxoplanet/starry/visualization.py
+++ b/src/jaxoplanet/starry/visualization.py
@@ -93,6 +93,7 @@ def show_surface(
             radius=radius,
             n=n,
             white_contour=white_contour,
+            ax=ax
         )
     ax.set_xlim(-1.02, 1.02)
     ax.set_ylim(-1.02, 1.02)


### PR DESCRIPTION
Here is a simple fix to `plot_lines` such that the graticule is plotted in the correct axis when axis is specified in`show_surface`.

```python
import matplotlib.pyplot as plt
import astropy.units as u
import numpy as np
import jax
import jax.numpy as jnp
from jaxoplanet.starry import Surface, show_surface
from jaxoplanet.starry.light_curves import light_curve
from jaxoplanet.starry.orbit import Body, Central, SurfaceSystem
from jaxoplanet.starry.doppler import radial_velocity

truths = {
    "star_mass": 0.8,
    "star_radius": 0.8,
    "star_period": 2.2,
    "planet_mass": 0.0001,
    "planet_radius": 0.05,
    "planet_period": 2.86,
    "ecc": 0,
    "imp": 0.5,
    "obl": jnp.deg2rad(60),
    "inc": np.pi/2, #jnp.deg2rad(90),
    "limb_dark_u": (0.5, 0.2),
}
surface = Surface(period=truths["star_period"], #rotation period
                   obl=truths["obl"], 
                   inc=truths["inc"], 
                   u=truths["limb_dark_u"]
                 )

star = Central(radius=truths["star_radius"], 
               mass=truths["star_mass"])
planet = Body(period=truths["planet_period"], 
              radius=truths["planet_radius"], 
              mass=truths["planet_mass"], 
              impact_param=truths["imp"])
system = SurfaceSystem(star, surface).add_body(planet)


# Unit conversion: Rsun/day -> km/s
factor = (u.Rsun / u.day).to(u.km / u.s)

# Parameter grids
time = jnp.linspace(-0.1, 0.1, 500)
obls = jnp.arange(-90, 91, 30)   # lambda (deg)
incs = jnp.arange(0, 91, 30)     # i_star (deg)

fig, axs = plt.subplots(
    7, 4,
    figsize=(10, 10),
    constrained_layout=True
)

axes = axs.flatten()
n = 0

for a, o in enumerate(obls):
    obl = jnp.deg2rad(o)

    for b, i in enumerate(incs):
        inc = jnp.deg2rad(i)

        # Build stellar surface
        surf = Surface(
            period=truths["star_period"],
            obl=obl,
            inc=inc,
            u=truths["limb_dark_u"]
        )

        # Build system consistently for this geometry
        sys = SurfaceSystem(star, surf).add_body(planet)

        # Planet sky-plane position (x, y)
        x, y = sys.bodies[0].position(time)[:2]

        ax = axes[n]

        # Render surface RV map
        im = show_surface(
            surf,
            rv=True,
            return_im=True,
            ax=ax
        )

        # Overlay transit chord
        ax.plot(x, y, linestyle="--", linewidth=3)

        # Column titles: stellar inclination
        if a == 0:
            ax.set_title(
                rf'$i_\star = {jnp.rad2deg(surf.inc):.0f}^\circ$'
            )

        # Row labels: projected obliquity
        if b == 0:
            ax.set_ylabel(
                rf'$\lambda = {jnp.rad2deg(surf.obl):.0f}^\circ$'
            )

        ax.set_aspect("equal")
        n += 1

plt.show()
```

Before the fix: graticule is only plotted in the last axis
<img width="901" height="1011" alt="graticule" src="https://github.com/user-attachments/assets/f895841e-d8e8-4fbd-9d9a-90c5f30d1753" />

After the fix: graticule is properly plotted in each axis
<img width="901" height="1011" alt="graticule_fixed" src="https://github.com/user-attachments/assets/48a297c3-c56e-4ef1-8d41-a39552864c43" />
