### PR TITLE
remove starry comparison tests since we can't satisfy jaxlib=0.4.13 version anymore.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,9 +26,6 @@ jobs:
           - os: "macos-latest"
             python-version: "3.12"
             session: "test"
-          - os: "ubuntu-22.04"
-            python-version: "3.10"
-            session: "comparison"
 
     steps:
       - name: "Init: checkout"

--- a/noxfile.py
+++ b/noxfile.py
@@ -20,25 +20,6 @@ def test_x64(session):
     session.run("pytest", "-n", "auto", *session.posargs, env=env)
 
 
-@nox.session(python=["3.10"])
-def comparison(session):
-    session.install(".[test,comparison]", "numpy<1.22")
-    session.run("python", "-c", "import starry")
-    session.run("python", "-c", "import theano")
-    session.run("pip", "freeze")
-    if session.posargs:
-        args = session.posargs
-    else:
-        args = ("tests/starry",)
-    session.run(
-        "pytest",
-        "-n",
-        "auto",
-        *args,
-        env={"JAX_ENABLE_X64": "True"},
-    )
-
-
 @nox.session
 def docs(session):
     session.install(".[docs]")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,6 @@ dev = [
 ]
 test = ["pytest", "pytest-xdist", "exoplanet-core", "batman-package"]
 test-math = ["mpmath", "gmpy2"]
-comparison = ["starry", "numpy", "tqdm", "xarray<2023.10.0"]
 docs = [
     "matplotlib",
     "arviz<1.0",


### PR DESCRIPTION
Reason for (temporarily) removing the starry/jaxoplanet comparison tests.

- starry/theano require `numpy<1.24`, but all jaxlib versions currently on PyPI require `numpy>=1.22` with no overlap that satisfies both
- `jaxlib==0.4.13` (the last version that worked) has been deleted from PyPI
- starry and theano are unmaintained so no upstream fix is coming
- future fix: save starry outputs as static fixtures rather than running starry live in CI