### PR TITLE
cap jax jaxlib version for now until numpyro handles xla_pmap_p deprecation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,8 +15,8 @@ classifiers = [
     "Programming Language :: Python :: 3",
 ]
 dynamic = ["version"]
-dependencies = ["jax",
-                "jaxlib",
+dependencies = ["jax<0.10",
+                "jaxlib<0.10",
                 "equinox",
                 ]
 


### PR DESCRIPTION
Temporarily cap the `jax` and `jaxlib` versions to be <0.10 since those releases deprecated C++ pmap infrastructure that is currently used in `numpyro`. See https://github.com/pyro-ppl/numpyro/pull/2173.

Once https://github.com/pyro-ppl/numpyro/pull/2173 is merged we should update `numpyro` and remove this `jax` version upper bound. 