### PR TITLE
Fix Rsun to arcsec conversion in Keplerian orbit with parallax 

### DIFF
--- a/src/jaxoplanet/orbits/keplerian.py
+++ b/src/jaxoplanet/orbits/keplerian.py
@@ -607,8 +607,7 @@ class OrbitalBody(eqx.Module):
             if parallax is None:
                 r0 = semimajor
             else:
-                # TODO
-                r0 = semimajor * constants.au * parallax
+                r0 = semimajor * parallax / constants.au
 
         sinf, cosf = self._get_true_anomaly(t)
         if self.eccentricity is None:

--- a/tests/orbits/keplerian_test.py
+++ b/tests/orbits/keplerian_test.py
@@ -138,6 +138,7 @@ def test_keplerian_body_coordinates_match_batman(time, system):
         no_transit |= r[~m] > 2
         assert np.all(no_transit)
 
+
 def test_keplerian_body_coordinates_parallax(time, system):
     body = system.bodies[0]
     plx = 25e-3

--- a/tests/orbits/keplerian_test.py
+++ b/tests/orbits/keplerian_test.py
@@ -138,6 +138,16 @@ def test_keplerian_body_coordinates_match_batman(time, system):
         no_transit |= r[~m] > 2
         assert np.all(no_transit)
 
+def test_keplerian_body_coordinates_parallax(time, system):
+    body = system.bodies[0]
+    plx = 25e-3
+    with jax.enable_x64(True):
+        x, y, _z = body.relative_position(time)
+        r = jnp.sqrt(x**2 + y**2)
+        x_plx, y_plx, _z_plx = body.relative_position(time, parallax=plx)
+        r_plx = jnp.sqrt(x_plx**2 + y_plx**2)
+        assert_allclose(r * plx / constants.au, r_plx)
+
 
 def test_keplerian_body_positions_small_star(time):
     _rsky = pytest.importorskip("batman._rsky")


### PR DESCRIPTION
I was trying to reproduce the [exoplanet astrometric fitting example](https://gallery.exoplanet.codes/tutorials/astrometric/) with `jaxoplanet` and encountered an issue with the separation being too large. It seems the issue was when converting r0 from Rsun (the units of `self.semimajor`) to arcsec, `jaxoplanet` was multipling by `constants.au` (the number of Rsun in an au) instead of dividing by it. This only happens when `parallax` is not `None`.

This PR adds a test for it and fixes the issue. I was wondering if it would be worth also testing this through a comparison with a well-tested astrometry package like orbitize! (this would require adding orbitize! as a test dependency).

Here is the notebook I used to test this: https://github.com/vandalt/jaxoplanet-astrometry/blob/main/notebooks/exoplanet_astrometry_fitting.ipynb.

I'd be happy to contribute this or another relative astrometry example as a tutorial if you think it would be useful. I'm also planning to do an astrometry+RV example soon.

Cheers!