### PR TITLE
Units and consistency updates to positions and velocities for astrometry and RV

### DIFF
--- a/docs/tutorials/quickstart.ipynb
+++ b/docs/tutorials/quickstart.ipynb
@@ -123,14 +123,12 @@
    "id": "10",
    "metadata": {},
    "source": [
-    "## Radial velocity"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "11",
-   "metadata": {},
-   "source": [
+    "## Radial velocity\n",
+    "\n",
+    "```{important}\n",
+    "Note that the radial velocity is returned in ``Rsun/day`` to follow the *jaxoplanet* [units convention](../conventions.ipynb). See the [Radial Velocities tutorial](../rv.ipynb) for more on this.\n",
+    "```\n",
+    "\n",
     "Then, one can access the relative position and velocity of the planet relative to the sun. "
    ]
   },

--- a/docs/tutorials/quickstart.ipynb
+++ b/docs/tutorials/quickstart.ipynb
@@ -135,7 +135,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "12",
+   "id": "11",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -150,7 +150,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "13",
+   "id": "12",
    "metadata": {},
    "source": [
     "```{note}\n",
@@ -163,7 +163,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "14",
+   "id": "13",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -187,7 +187,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "15",
+   "id": "14",
    "metadata": {},
    "source": [
     "## Occultation light curve of limb darkened star\n",
@@ -200,7 +200,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "16",
+   "id": "15",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -214,7 +214,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "17",
+   "id": "16",
    "metadata": {},
    "source": [
     "and plot the resulting light curve"
@@ -223,7 +223,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "18",
+   "id": "17",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -234,7 +234,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "19",
+   "id": "18",
    "metadata": {},
    "source": [
     "## Non-uniform stars\n",
@@ -251,7 +251,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "20",
+   "id": "19",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -272,7 +272,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "21",
+   "id": "20",
    "metadata": {},
    "source": [
     "### Rotational light curves\n",
@@ -283,7 +283,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "22",
+   "id": "21",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -294,7 +294,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "23",
+   "id": "22",
    "metadata": {},
    "source": [
     "from which we compute the rotational light curve of the star"
@@ -303,7 +303,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "24",
+   "id": "23",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -321,7 +321,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "25",
+   "id": "24",
    "metadata": {},
    "source": [
     "### Occultation light curve"
@@ -329,7 +329,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "26",
+   "id": "25",
    "metadata": {},
    "source": [
     "We can add a body to the system, having its own surface"
@@ -338,7 +338,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "27",
+   "id": "26",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -359,7 +359,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "28",
+   "id": "27",
    "metadata": {},
    "source": [
     "and compute the occultation light curve of the system"
@@ -368,7 +368,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "29",
+   "id": "28",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -380,7 +380,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "30",
+   "id": "29",
    "metadata": {},
    "source": [
     "Let's plot it and show the system over time"
@@ -389,7 +389,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "31",
+   "id": "30",
    "metadata": {},
    "outputs": [],
    "source": [

--- a/docs/tutorials/quickstart.ipynb
+++ b/docs/tutorials/quickstart.ipynb
@@ -126,7 +126,7 @@
     "## Radial velocity\n",
     "\n",
     "```{important}\n",
-    "Note that the radial velocity is returned in ``Rsun/day`` to follow the *jaxoplanet* [units convention](../conventions.ipynb). See the [Radial Velocities tutorial](../rv.ipynb) for more on this.\n",
+    "Note that the radial velocity is returned in `Rsun/day` to follow the *jaxoplanet* [units convention](../conventions.ipynb). See the [Radial Velocities tutorial](./rv.ipynb) for more on this.\n",
     "```\n",
     "\n",
     "Then, one can access the relative position and velocity of the planet relative to the sun. "

--- a/docs/tutorials/rv.ipynb
+++ b/docs/tutorials/rv.ipynb
@@ -9,7 +9,7 @@
     "# Radial Velocities\n",
     "\n",
     "\n",
-    "In this tutorial we will learn how to use `jaxoplanet` to compute the radial velocities of a star hosting a single exoplanet, and how to fit this dataset using `numpyro`.\n",
+    "In this tutorial we will learn how to use `jaxoplanet` to compute the radial velocities (RVs) of a star hosting a single exoplanet, and how to fit this dataset using `numpyro`.\n",
     "\n",
     "```{note}\n",
     "This tutorial requires some [extra packages](about.ipynb) that are not included in the `jaxoplanet` dependencies.\n",
@@ -39,7 +39,11 @@
    "source": [
     "## Model and dataset\n",
     "\n",
-    "Let's first generate our dataset, consisting in the radial velocities of a star orbited by a unique exoplanet. We start by defining the system (see for more details)"
+    "Let's first generate our dataset, consisting in the radial velocities of a star orbited by a unique exoplanet. We start by defining the system (see for more details)\n",
+    "\n",
+    "```{important}\n",
+    "Note that the radial velocity is returned in `Rsun/day`. Checkout the [units convention](../conventions.ipynb) to learn more about units in *jaxoplanet* and keep reading to see how you can easily convert velocities to m/s.\n",
+    "```"
    ]
   },
   {
@@ -51,8 +55,10 @@
     "import numpy as np\n",
     "import matplotlib.pyplot as plt\n",
     "from jaxoplanet.orbits import keplerian\n",
+    "from jaxoplanet import constants\n",
     "\n",
-    "truth = dict(mass=0.02, period=3.0)\n",
+    "# Convert 1.5 Mjup to Msun for jaxoplanet\n",
+    "truth = dict(mass=1.5 * constants.M_jup, period=3.0)\n",
     "star = keplerian.Central(mass=1.0, radius=1.0)\n",
     "system = keplerian.System(star).add_body(**truth)"
    ]
@@ -77,7 +83,10 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We can now compute the radial velocities of the star and add some noise to simulate our dataset"
+    "We can now compute the radial velocities of the star and add some noise to simulate our dataset\n",
+    "\n",
+    "Note that `jaxoplanet` follows a consistent [units convention](../conventions.ipynb) and returns RVs in `Rsun/day`.\n",
+    "Since it is much more common to work with RVs in `m/s` for exoplanet research, we will convert all velocities in m/s for this tutorial. The `jaxoplanet.constants` module has a helper `m_per_s` constant to help us do that."
    ]
   },
   {
@@ -88,17 +97,17 @@
    "source": [
     "np.random.seed(10)\n",
     "over_time = np.linspace(0, 10, 1000)\n",
-    "over_rvs = system.radial_velocity(over_time)[0]\n",
+    "over_rvs = system.radial_velocity(over_time)[0] / constants.m_per_s\n",
     "time = np.sort(np.random.uniform(0, 10, 40))\n",
-    "rv_obs = system.radial_velocity(time)[0]\n",
-    "rv_err = 0.05\n",
+    "rv_obs = system.radial_velocity(time)[0] / constants.m_per_s\n",
+    "rv_err = 20.0  # m/s\n",
     "rv_obs += rv_err * np.random.normal(size=len(time))\n",
     "\n",
     "\n",
     "def plot_data():\n",
     "    plt.errorbar(time, rv_obs, yerr=rv_err, fmt=\"+k\")\n",
     "    plt.xlabel(\"time (days)\")\n",
-    "    plt.ylabel(r\"radial velocity ($R_\\odot/d$)\")\n",
+    "    plt.ylabel(r\"radial velocity (m/s)\")\n",
     "\n",
     "\n",
     "plt.plot(over_time, over_rvs)\n",
@@ -111,7 +120,9 @@
    "source": [
     "## Inference\n",
     "\n",
-    "We will infer the value and associated uncertainty of the system orbital parameters using `numpyro`. In order to do that we first define a callable `model` function"
+    "We will infer the value and associated uncertainty of the system orbital parameters using `numpyro`. In order to do that we first define a callable `model` function\n",
+    "\n",
+    "Since it is more common to fit the planet mass in Jupiter masses, we convert the planet mass internally in the model via the `M_jup` constant so that the parameters can be expressed in Jupiter masses instead of solar masses, which `jaxoplanet` expects."
    ]
   },
   {
@@ -125,15 +136,15 @@
     "\n",
     "def rv_model(time, params):\n",
     "    system = keplerian.System(star).add_body(\n",
-    "        mass=params[\"mass\"], period=params[\"period\"]\n",
+    "        mass=params[\"mass\"] * constants.M_jup, period=params[\"period\"]\n",
     "    )\n",
-    "    return system.radial_velocity(time)[0]\n",
+    "    return system.radial_velocity(time)[0] / constants.m_per_s\n",
     "\n",
     "\n",
     "def model(time, y=None):\n",
-    "    mass = numpyro.sample(\"mass\", dist.Uniform(0.01, 0.1))\n",
+    "    mass = numpyro.sample(\"mass\", dist.Uniform(0.1, 10.0))\n",
     "    period = numpyro.sample(\"period\", dist.Uniform(1.0, 10.0))\n",
-    "    error = numpyro.sample(\"error\", dist.Uniform(0.01, 0.08))\n",
+    "    error = numpyro.sample(\"error\", dist.Uniform(0.1, 100.0))\n",
     "    rv = rv_model(time, {\"mass\": mass, \"period\": period})\n",
     "\n",
     "    # the likelihood function\n",
@@ -153,7 +164,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "init_values = {\"mass\": 0.022, \"period\": 3.01, \"error\": rv_err}\n",
+    "init_values = {\"mass\": 1.0, \"period\": 3.01, \"error\": rv_err}\n",
     "init_model = rv_model(over_time, init_values)\n",
     "\n",
     "plt.plot(over_time, init_model, \"C0\")\n",
@@ -224,11 +235,14 @@
    "outputs": [],
    "source": [
     "import corner\n",
+    "import arviz as az\n",
+    "\n",
+    "idata = az.from_numpyro(sampler)\n",
     "\n",
     "_ = corner.corner(\n",
-    "    samples,\n",
+    "    idata,\n",
     "    var_names=[\"mass\", \"period\"],\n",
-    "    truths=[truth[\"mass\"], truth[\"period\"]],\n",
+    "    truths=[truth[\"mass\"] / constants.M_jup, truth[\"period\"]],\n",
     "    show_titles=True,\n",
     "    quantiles=[0.16, 0.5, 0.84],\n",
     "    title_fmt=\".4f\",\n",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ dev = [
     "gmpy2",
     "astropy"
 ]
-test = ["pytest", "pytest-xdist", "exoplanet-core", "batman-package", "radvel"]
+test = ["pytest", "pytest-xdist", "exoplanet-core", "batman-package", "radvel", "orbitize"]
 test-math = ["mpmath", "gmpy2"]
 docs = [
     "matplotlib",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ dev = [
     "gmpy2",
     "astropy"
 ]
-test = ["pytest", "pytest-xdist", "exoplanet-core", "batman-package"]
+test = ["pytest", "pytest-xdist", "exoplanet-core", "batman-package", "radvel"]
 test-math = ["mpmath", "gmpy2"]
 docs = [
     "matplotlib",

--- a/src/jaxoplanet/constants.py
+++ b/src/jaxoplanet/constants.py
@@ -3,3 +3,7 @@ G = 2942.2062175044193
 # (1 * u.au).to(u.R_sun).value
 au = 215.03215567054764
 M_earth = 3.0034893488507934e-06
+# (1 * u.Mjup).to("Msun").value
+M_jup = 0.0009545942339693249
+# (1 * u.Rsun / (1 * u.day)).to(u.m / u.s).value
+R_sun_per_day = 8052.083333333333

--- a/src/jaxoplanet/constants.py
+++ b/src/jaxoplanet/constants.py
@@ -5,5 +5,5 @@ au = 215.03215567054764
 M_earth = 3.0034893488507934e-06
 # (1 * u.Mjup).to("Msun").value
 M_jup = 0.0009545942339693249
-# (1 * u.Rsun / (1 * u.day)).to(u.m / u.s).value
-R_sun_per_day = 8052.083333333333
+# (1 * u.m / u.s).to(u.Rsun / u.day).value
+m_per_s = 0.00012419146183699872

--- a/src/jaxoplanet/orbits/keplerian.py
+++ b/src/jaxoplanet/orbits/keplerian.py
@@ -373,7 +373,8 @@ class OrbitalBody(eqx.Module):
 
         Returns:
             The components of the position vector at ``t`` in units of
-            ``R_sun``.
+            ``R_sun``, but if parallax is provided or ``self.parallax`` is not None,
+            then in units of arcseconds.
         """
         semimajor = -self.semimajor * self.central.mass / self.total_mass
         return self._get_position_and_velocity(
@@ -390,7 +391,8 @@ class OrbitalBody(eqx.Module):
 
         Returns:
             The components of the position vector at ``t`` in units of
-            ``R_sun``.
+            ``R_sun``, but if parallax is provided or ``self.parallax`` is not None,
+            then in units of arcseconds.
         """
         semimajor = self.semimajor * self.mass / self.total_mass
         return self._get_position_and_velocity(
@@ -407,7 +409,8 @@ class OrbitalBody(eqx.Module):
 
         Returns:
             The components of the position vector at ``t`` in units of
-            ``R_sun``.
+            ``R_sun``, but if parallax is provided or ``self.parallax`` is not None,
+            then in units of arcseconds.
         """
         return self._get_position_and_velocity(
             t,
@@ -447,7 +450,8 @@ class OrbitalBody(eqx.Module):
 
         Returns:
             The components of the velocity vector at ``t`` in units of
-            ``R_sun/day``.
+            ``R_sun/day``, but if parallax is provided or ``self.parallax`` is not None,
+            then in units of arcseconds/day.
         """
         if semiamplitude is None:
             mass: Scalar = -self.central.mass  # type: ignore
@@ -469,7 +473,8 @@ class OrbitalBody(eqx.Module):
 
         Returns:
             The components of the velocity vector at ``t`` in units of
-            ``R_sun/day``.
+            ``R_sun/day``, but if parallax is provided or ``self.parallax`` is not None,
+            then in units of arcseconds/day.
         """
         if semiamplitude is None:
             return self._get_position_and_velocity(t, mass=self.mass)[1]
@@ -490,7 +495,8 @@ class OrbitalBody(eqx.Module):
 
         Returns:
             The components of the velocity vector at ``t`` in units of
-            ``R_sun/day``.
+            ``R_sun/day``, but if parallax is provided or ``self.parallax`` is not None,
+            then in units of arcseconds/day.
         """
         if semiamplitude is None:
             mass: Scalar = -self.total_mass  # type: ignore
@@ -514,9 +520,12 @@ class OrbitalBody(eqx.Module):
                 this amplitude will be used instead.
 
         Returns:
-            The reflex radial velocity evaluated at ``t`` in units of ``R_sun/day``.
+            The reflex radial velocity evaluated at ``t`` in units of ``m/s``.
         """
-        return -self.central_velocity(t, semiamplitude=semiamplitude)[2]  # type: ignore
+        rv_rsun_d = -self.central_velocity(t, semiamplitude=semiamplitude)[2]
+        if self.parallax is not None:
+            rv_rsun_d = rv_rsun_d / self.parallax * constants.au
+        return rv_rsun_d * constants.R_sun_per_day  # type: ignore
 
     def _warp_times(self, t: Scalar) -> Scalar:
         return t - self.time_transit  # type: ignore
@@ -597,6 +606,8 @@ class OrbitalBody(eqx.Module):
             else:
                 k0 = self.radial_velocity_semiamplitude
 
+            if parallax is not None:
+                k0 = k0 * parallax / constants.au
         else:
             k0 = semiamplitude
 

--- a/src/jaxoplanet/orbits/keplerian.py
+++ b/src/jaxoplanet/orbits/keplerian.py
@@ -597,8 +597,6 @@ class OrbitalBody(eqx.Module):
             else:
                 k0 = self.radial_velocity_semiamplitude
 
-            if parallax is not None:
-                k0 = k0 * constants.au * parallax
         else:
             k0 = semiamplitude
 

--- a/src/jaxoplanet/orbits/keplerian.py
+++ b/src/jaxoplanet/orbits/keplerian.py
@@ -469,7 +469,7 @@ class OrbitalBody(eqx.Module):
 
         Returns:
             The components of the velocity vector at ``t`` in units of
-            ``M_sun/day``.
+            ``R_sun/day``.
         """
         if semiamplitude is None:
             return self._get_position_and_velocity(t, mass=self.mass)[1]
@@ -490,7 +490,7 @@ class OrbitalBody(eqx.Module):
 
         Returns:
             The components of the velocity vector at ``t`` in units of
-            ``M_sun/day``.
+            ``R_sun/day``.
         """
         if semiamplitude is None:
             mass: Scalar = -self.total_mass  # type: ignore
@@ -514,7 +514,7 @@ class OrbitalBody(eqx.Module):
                 this amplitude will be used instead.
 
         Returns:
-            The reflex radial velocity evaluated at ``t``.
+            The reflex radial velocity evaluated at ``t`` in units of ``R_sun/day``.
         """
         return -self.central_velocity(t, semiamplitude=semiamplitude)[2]  # type: ignore
 

--- a/src/jaxoplanet/orbits/keplerian.py
+++ b/src/jaxoplanet/orbits/keplerian.py
@@ -41,7 +41,9 @@ class Central(eqx.Module):
 
         # Check that all the input values are scalars; we don't support Scalars
         # here
-        if any(jnp.ndim(arg) != 0 for arg in (mass, radius, density) if arg is not None):
+        if any(
+            jnp.ndim(arg) != 0 for arg in (mass, radius, density) if arg is not None
+        ):
             raise ValueError("All parameters of a KeplerianCentral must be scalars")
 
         # Compute all three parameters based on the input values
@@ -228,7 +230,9 @@ class Body(eqx.Module):
             )
 
         if self.impact_param is not None and self.inclination is not None:
-            raise ValueError("Only one of impact_param and inclination can be specified")
+            raise ValueError(
+                "Only one of impact_param and inclination can be specified"
+            )
 
         if self.time_transit is not None and self.time_peri is not None:
             raise ValueError("Only one of time_transit or time_peri can be specified")

--- a/src/jaxoplanet/orbits/keplerian.py
+++ b/src/jaxoplanet/orbits/keplerian.py
@@ -520,16 +520,16 @@ class OrbitalBody(eqx.Module):
                 this amplitude will be used instead.
 
         Returns:
-            The reflex radial velocity evaluated at ``t`` in units of ``m/s``.
+            The reflex radial velocity evaluated at ``t`` in units of ``R_sun/day``.
         """
-        rv_rsun_d = -self.central_velocity(t, semiamplitude=semiamplitude)[2]
+        rv = -self.central_velocity(t, semiamplitude=semiamplitude)[2]
         if (
             self.parallax is not None
             and semiamplitude is None
             and self.radial_velocity_semiamplitude is None
         ):
-            rv_rsun_d = rv_rsun_d / self.parallax * constants.au
-        return rv_rsun_d * constants.R_sun_per_day  # type: ignore
+            rv = rv / self.parallax * constants.au
+        return rv
 
     def _warp_times(self, t: Scalar) -> Scalar:
         return t - self.time_transit  # type: ignore

--- a/src/jaxoplanet/orbits/keplerian.py
+++ b/src/jaxoplanet/orbits/keplerian.py
@@ -41,9 +41,7 @@ class Central(eqx.Module):
 
         # Check that all the input values are scalars; we don't support Scalars
         # here
-        if any(
-            jnp.ndim(arg) != 0 for arg in (mass, radius, density) if arg is not None
-        ):
+        if any(jnp.ndim(arg) != 0 for arg in (mass, radius, density) if arg is not None):
             raise ValueError("All parameters of a KeplerianCentral must be scalars")
 
         # Compute all three parameters based on the input values
@@ -230,9 +228,7 @@ class Body(eqx.Module):
             )
 
         if self.impact_param is not None and self.inclination is not None:
-            raise ValueError(
-                "Only one of impact_param and inclination can be specified"
-            )
+            raise ValueError("Only one of impact_param and inclination can be specified")
 
         if self.time_transit is not None and self.time_peri is not None:
             raise ValueError("Only one of time_transit or time_peri can be specified")
@@ -523,7 +519,11 @@ class OrbitalBody(eqx.Module):
             The reflex radial velocity evaluated at ``t`` in units of ``m/s``.
         """
         rv_rsun_d = -self.central_velocity(t, semiamplitude=semiamplitude)[2]
-        if self.parallax is not None:
+        if (
+            self.parallax is not None
+            and semiamplitude is None
+            and self.radial_velocity_semiamplitude is None
+        ):
             rv_rsun_d = rv_rsun_d / self.parallax * constants.au
         return rv_rsun_d * constants.R_sun_per_day  # type: ignore
 

--- a/tests/orbits/keplerian_test.py
+++ b/tests/orbits/keplerian_test.py
@@ -169,7 +169,40 @@ def test_keplerian_body_coordinates_parallax(time, system):
         assert_allclose(r * conv_factor, r_plx)
 
 
-def test_keplerian_rv(time, system):
+def test_keplerian_body_coordinates_orbitize(time, system):
+    kepler = pytest.importorskip("orbitize.kepler")
+    rv = system.radial_velocity(time)[0]
+    rv_orb = 0
+    time_np = np.array(time, dtype=np.float64)
+    with jax.enable_x64(True):
+        for body in system.bodies:
+            P = float(body.period)
+            T0 = float(body.time_peri)
+            ref_epoch = 0.0
+            tau = ((T0 - ref_epoch) / P) % 1
+            ra_orb, dec_orb, rv_orb_body = kepler.calc_orbit(
+                time_np,
+                float(body.semimajor) / constants.au,
+                float(body.eccentricity if body.eccentricity else 0.0),
+                float(body.inclination),
+                float(body.omega_peri if body.omega_peri else 0.0) + np.pi,
+                float(jnp.arccos(body.cos_asc_node) if body.cos_asc_node else 0.0),
+                tau,
+                float(body.parallax * 1e3 if body.parallax else 1.0),
+                float(body.total_mass),
+                float(body.mass),
+                tau_ref_epoch=ref_epoch,
+            )
+            rv_orb += rv_orb_body
+
+            x, y, _z = body.relative_position(time)
+            pos_factor = constants.au**-1 if body.parallax is None else 1e3
+            assert_allclose(y * pos_factor, ra_orb)
+            assert_allclose(x * pos_factor, dec_orb)
+        assert_allclose(rv * 1e-3, -rv_orb)
+
+
+def test_keplerian_rv_match_radvel(time, system):
     kepler = pytest.importorskip("radvel.kepler")
     radvel_utils = pytest.importorskip("radvel.utils")
     with jax.enable_x64(True):

--- a/tests/orbits/keplerian_test.py
+++ b/tests/orbits/keplerian_test.py
@@ -405,7 +405,9 @@ def body_vmap_func4(body, x):
 def test_body_vmap(func, in_axes, out_axes, args):
     central = Central()
     vmap_sys = (
-        System(central).add_body(radius=0.5, period=1.0).add_body(radius=0.8, period=1.0)
+        System(central)
+        .add_body(radius=0.5, period=1.0)
+        .add_body(radius=0.8, period=1.0)
     )
     no_vmap_sys = (
         System(central)

--- a/tests/orbits/keplerian_test.py
+++ b/tests/orbits/keplerian_test.py
@@ -55,7 +55,7 @@ from jaxoplanet.test_utils import assert_allclose, assert_pytree_allclose
             "central": Central(mass=1.3, radius=1.1),
             "bodies": [
                 Body(
-                    radial_velocity_semiamplitude=10 / constants.R_sun_per_day,
+                    radial_velocity_semiamplitude=10 * constants.m_per_s,
                     time_transit=0.1,
                     period=12.5,
                     inclination=0.3,
@@ -192,7 +192,7 @@ def test_keplerian_body_coordinates_parallax(time, system):
 def test_keplerian_body_coordinates_orbitize(time, system):
     kepler = pytest.importorskip("orbitize.kepler")
 
-    rv = system.radial_velocity(time)[0]
+    rv = system.radial_velocity(time)[0] / constants.m_per_s
     rv_orb = 0
     time_np = np.array(time, dtype=np.float64)
     with jax.enable_x64(True):
@@ -213,7 +213,7 @@ def test_keplerian_body_coordinates_orbitize(time, system):
             if body.mass is None:
                 Msini = (
                     body.radial_velocity_semiamplitude
-                    * constants.R_sun_per_day
+                    / constants.m_per_s
                     / K_0
                     * np.sqrt(1.0 - e**2.0)
                     * (Mstar) ** (2.0 / 3.0)
@@ -249,7 +249,7 @@ def test_keplerian_rv_match_radvel(time, system):
     kepler = pytest.importorskip("radvel.kepler")
     radvel_utils = pytest.importorskip("radvel.utils")
     with jax.enable_x64(True):
-        rv = system.radial_velocity(time)[0]
+        rv = system.radial_velocity(time)[0] / constants.m_per_s
         rv_radvel = 0
         for body in system.bodies:
             P = float(body.period)
@@ -260,7 +260,7 @@ def test_keplerian_rv_match_radvel(time, system):
                     Msini, P, float(body.total_mass), e, Msini_units="jupiter"
                 )
             else:
-                K = body.radial_velocity_semiamplitude * constants.R_sun_per_day
+                K = body.radial_velocity_semiamplitude / constants.m_per_s
             orbel_synth = np.array(
                 [
                     P,
@@ -343,8 +343,8 @@ def test_keplerian_system_radial_velocity():
             # but the ecc=0 model doesn't give the same results as the ecc=None
             # model otherwise.
             atol={
-                jnp.float32: 5e-6 * constants.R_sun_per_day,
-                jnp.float64: 1e-12 * constants.R_sun_per_day,
+                jnp.float32: 5e-6,
+                jnp.float64: 1e-12,
             },
         )
 

--- a/tests/orbits/keplerian_test.py
+++ b/tests/orbits/keplerian_test.py
@@ -296,7 +296,10 @@ def test_keplerian_system_radial_velocity():
             # TODO(dfm): I'm not sure why we need to loosen the tolerance here,
             # but the ecc=0 model doesn't give the same results as the ecc=None
             # model otherwise.
-            atol={jnp.float32: 5e-6 * constants.R_sun_per_day, jnp.float64: 1e-12},
+            atol={
+                jnp.float32: 5e-6 * constants.R_sun_per_day,
+                jnp.float64: 1e-12 * constants.R_sun_per_day,
+            },
         )
 
 

--- a/tests/orbits/keplerian_test.py
+++ b/tests/orbits/keplerian_test.py
@@ -51,6 +51,21 @@ from jaxoplanet.test_utils import assert_allclose, assert_pytree_allclose
                 )
             ],
         },
+        {
+            "central": Central(mass=1.3, radius=1.1),
+            "bodies": [
+                Body(
+                    radial_velocity_semiamplitude=10 / constants.R_sun_per_day,
+                    time_transit=0.1,
+                    period=12.5,
+                    inclination=0.3,
+                    eccentricity=0.3,
+                    omega_peri=-1.5,
+                    asc_node=0.3,
+                    parallax=25e-3,
+                )
+            ],
+        },
     ]
 )
 def system(request):
@@ -96,6 +111,11 @@ def test_keplerian_body_keplers_law():
 @pytest.mark.parametrize("prefix", ["", "central_", "relative_"])
 def test_keplerian_body_velocity(time, system, prefix):
     body = system.bodies[0]
+    if body.radial_velocity_semiamplitude is not None:
+        pytest.skip(
+            "velocity will not be the derivative of position when "
+            "radial_velocity_semiamplitude is set"
+        )
     v = getattr(body, f"{prefix}velocity")(time)
     for i, v_ in enumerate(v):
         pos_func = getattr(body, f"{prefix}position")
@@ -171,6 +191,7 @@ def test_keplerian_body_coordinates_parallax(time, system):
 
 def test_keplerian_body_coordinates_orbitize(time, system):
     kepler = pytest.importorskip("orbitize.kepler")
+
     rv = system.radial_velocity(time)[0]
     rv_orb = 0
     time_np = np.array(time, dtype=np.float64)
@@ -180,17 +201,39 @@ def test_keplerian_body_coordinates_orbitize(time, system):
             T0 = float(body.time_peri)
             ref_epoch = 0.0
             tau = ((T0 - ref_epoch) / P) % 1
+            e = float(body.eccentricity if body.eccentricity else 0.0)
+            Mstar = float(body.total_mass)
+            # Normalization.
+            # RV m/s of a 1.0 Jupiter mass planet tugging on a 1.0
+            # solar mass star on a 1.0 year orbital period
+            K_0 = 28.4329
+            inc = float(body.inclination)
+
+            # TODO: Double check unites and varialbe names
+            if body.mass is None:
+                Msini = (
+                    body.radial_velocity_semiamplitude
+                    * constants.R_sun_per_day
+                    / K_0
+                    * np.sqrt(1.0 - e**2.0)
+                    * (Mstar) ** (2.0 / 3.0)
+                    * (P / 365.25) ** (1 / 3.0)
+                )
+                mass = float(Msini / jnp.sin(inc)) * constants.M_jup
+            else:
+                mass = float(body.mass)
+
             ra_orb, dec_orb, rv_orb_body = kepler.calc_orbit(
                 time_np,
                 float(body.semimajor) / constants.au,
-                float(body.eccentricity if body.eccentricity else 0.0),
-                float(body.inclination),
+                e,
+                inc,
                 float(body.omega_peri if body.omega_peri else 0.0) + np.pi,
                 float(jnp.arccos(body.cos_asc_node) if body.cos_asc_node else 0.0),
                 tau,
                 float(body.parallax * 1e3 if body.parallax else 1.0),
-                float(body.total_mass),
-                float(body.mass),
+                Mstar,
+                mass,
                 tau_ref_epoch=ref_epoch,
             )
             rv_orb += rv_orb_body
@@ -209,12 +252,15 @@ def test_keplerian_rv_match_radvel(time, system):
         rv = system.radial_velocity(time)[0]
         rv_radvel = 0
         for body in system.bodies:
-            Msini = float(body.mass * np.sin(body.inclination)) / constants.M_jup
             P = float(body.period)
             e = float(body.eccentricity if body.eccentricity else 0.0)
-            K = radvel_utils.semi_amplitude(
-                Msini, P, float(body.total_mass), e, Msini_units="jupiter"
-            )
+            if body.mass is not None:
+                Msini = float(body.mass * np.sin(body.inclination)) / constants.M_jup
+                K = radvel_utils.semi_amplitude(
+                    Msini, P, float(body.total_mass), e, Msini_units="jupiter"
+                )
+            else:
+                K = body.radial_velocity_semiamplitude * constants.R_sun_per_day
             orbel_synth = np.array(
                 [
                     P,
@@ -359,9 +405,7 @@ def body_vmap_func4(body, x):
 def test_body_vmap(func, in_axes, out_axes, args):
     central = Central()
     vmap_sys = (
-        System(central)
-        .add_body(radius=0.5, period=1.0)
-        .add_body(radius=0.8, period=1.0)
+        System(central).add_body(radius=0.5, period=1.0).add_body(radius=0.8, period=1.0)
     )
     no_vmap_sys = (
         System(central)

--- a/tests/orbits/keplerian_test.py
+++ b/tests/orbits/keplerian_test.py
@@ -1,4 +1,3 @@
-import equinox as eqx
 import jax
 import jax.experimental
 import jax.numpy as jnp
@@ -114,7 +113,8 @@ def test_keplerian_body_radial_velocity(time, system):
 
 def test_keplerian_body_impact_parameter(system):
     body = system.bodies[0]
-    x, y, z = body.relative_position(body.time_transit)
+    plx_factor = constants.au if body.parallax else None
+    x, y, z = body.relative_position(body.time_transit, parallax=plx_factor)
     assert_allclose(
         (jnp.sqrt(x**2 + y**2) / system.central.radius),
         body.impact_param,
@@ -140,7 +140,9 @@ def test_keplerian_body_coordinates_match_batman(time, system):
         m = r_batman < 100.0
         assert m.sum() > 0
 
-        x, y, z = body.relative_position(time)
+        x, y, z = body.relative_position(
+            time, parallax=constants.au if body.parallax else None
+        )
         r = jnp.sqrt(x**2 + y**2)
 
         # Make sure that the in-transit impact parameter matches batman
@@ -167,17 +169,11 @@ def test_keplerian_body_coordinates_parallax(time, system):
         assert_allclose(r * conv_factor, r_plx)
 
 
-@pytest.mark.parametrize("plx", [None, 25e-3])
-def test_keplerian_rv(time, system, plx):
+def test_keplerian_rv(time, system):
     kepler = pytest.importorskip("radvel.kepler")
     radvel_utils = pytest.importorskip("radvel.utils")
-    if plx is not None:
-        body = eqx.tree_at(
-            lambda b: b.parallax, system.bodies[0], plx, is_leaf=lambda x: x is None
-        )
-        system = System(central=system.central, bodies=[body])
     with jax.enable_x64(True):
-        rv = system.radial_velocity(time)[0] * constants.R_sun_per_day
+        rv = system.radial_velocity(time)[0]
         rv_radvel = 0
         for body in system.bodies:
             Msini = float(body.mass * np.sin(body.inclination)) / constants.M_jup
@@ -267,7 +263,7 @@ def test_keplerian_system_radial_velocity():
             # TODO(dfm): I'm not sure why we need to loosen the tolerance here,
             # but the ecc=0 model doesn't give the same results as the ecc=None
             # model otherwise.
-            atol={jnp.float32: 5e-6, jnp.float64: 1e-12},
+            atol={jnp.float32: 5e-6 * constants.R_sun_per_day, jnp.float64: 1e-12},
         )
 
 
@@ -327,9 +323,7 @@ def body_vmap_func4(body, x):
 def test_body_vmap(func, in_axes, out_axes, args):
     central = Central()
     vmap_sys = (
-        System(central)
-        .add_body(radius=0.5, period=1.0)
-        .add_body(radius=0.8, period=1.0)
+        System(central).add_body(radius=0.5, period=1.0).add_body(radius=0.8, period=1.0)
     )
     no_vmap_sys = (
         System(central)

--- a/tests/orbits/keplerian_test.py
+++ b/tests/orbits/keplerian_test.py
@@ -37,6 +37,21 @@ from jaxoplanet.test_utils import assert_allclose, assert_pytree_allclose
                 )
             ],
         },
+        {
+            "central": Central(mass=1.3, radius=1.1),
+            "bodies": [
+                Body(
+                    mass=0.1,
+                    time_transit=0.1,
+                    period=12.5,
+                    inclination=0.3,
+                    eccentricity=0.3,
+                    omega_peri=-1.5,
+                    asc_node=0.3,
+                    parallax=25e-3,
+                )
+            ],
+        },
     ]
 )
 def system(request):
@@ -146,9 +161,10 @@ def test_keplerian_body_coordinates_parallax(time, system):
     with jax.enable_x64(True):
         x, y, _z = body.relative_position(time)
         r = jnp.sqrt(x**2 + y**2)
+        conv_factor = plx / constants.au if body.parallax is None else 1.0
         x_plx, y_plx, _z_plx = body.relative_position(time, parallax=plx)
         r_plx = jnp.sqrt(x_plx**2 + y_plx**2)
-        assert_allclose(r * plx / constants.au, r_plx)
+        assert_allclose(r * conv_factor, r_plx)
 
 
 @pytest.mark.parametrize("plx", [None, 25e-3])

--- a/tests/orbits/keplerian_test.py
+++ b/tests/orbits/keplerian_test.py
@@ -1,3 +1,4 @@
+import equinox as eqx
 import jax
 import jax.experimental
 import jax.numpy as jnp
@@ -148,6 +149,38 @@ def test_keplerian_body_coordinates_parallax(time, system):
         x_plx, y_plx, _z_plx = body.relative_position(time, parallax=plx)
         r_plx = jnp.sqrt(x_plx**2 + y_plx**2)
         assert_allclose(r * plx / constants.au, r_plx)
+
+
+@pytest.mark.parametrize("plx", [None, 25e-3])
+def test_keplerian_rv(time, system, plx):
+    kepler = pytest.importorskip("radvel.kepler")
+    radvel_utils = pytest.importorskip("radvel.utils")
+    if plx is not None:
+        body = eqx.tree_at(
+            lambda b: b.parallax, system.bodies[0], plx, is_leaf=lambda x: x is None
+        )
+        system = System(central=system.central, bodies=[body])
+    with jax.enable_x64(True):
+        rv = system.radial_velocity(time)[0] * constants.R_sun_per_day
+        rv_radvel = 0
+        for body in system.bodies:
+            Msini = float(body.mass * np.sin(body.inclination)) / constants.M_jup
+            P = float(body.period)
+            e = float(body.eccentricity if body.eccentricity else 0.0)
+            K = radvel_utils.semi_amplitude(
+                Msini, P, float(body.total_mass), e, Msini_units="jupiter"
+            )
+            orbel_synth = np.array(
+                [
+                    P,
+                    float(body.time_peri),
+                    e,
+                    float(body.omega_peri if body.omega_peri else 0.0),
+                    K,
+                ]
+            )
+            rv_radvel += kepler.rv_drive(np.array(time, dtype=np.float64), orbel_synth)
+        assert_allclose(rv, rv_radvel)
 
 
 def test_keplerian_body_positions_small_star(time):

--- a/tests/orbits/keplerian_test.py
+++ b/tests/orbits/keplerian_test.py
@@ -356,7 +356,9 @@ def body_vmap_func4(body, x):
 def test_body_vmap(func, in_axes, out_axes, args):
     central = Central()
     vmap_sys = (
-        System(central).add_body(radius=0.5, period=1.0).add_body(radius=0.8, period=1.0)
+        System(central)
+        .add_body(radius=0.5, period=1.0)
+        .add_body(radius=0.8, period=1.0)
     )
     no_vmap_sys = (
         System(central)


### PR DESCRIPTION
Following #319, I started working on a [combined RV + relative astrometry](https://github.com/vandalt/jaxoplanet-astrometry/blob/main/notebooks/bpic_astrometry_rv.ipynb) example. And encountered some issue. Instead of working around them in the notebook, I tried to implement fixes here directly.

Here is the list of changes:

- **Fix** the arcsec conversion for velocity by dividing by `constants.au` like #319 did for position.
- **Fix** the position and velocity docstrings to mention that arcseconds are used when the parallax is provided or set at the object-level.
- **Modify** the `radial_velocity` function to return the RVs in units of m/s (**breaking change**)
- **Add** `M_jup` (in units of `M_sun`) and (`R_sun_per_d` in units of `m/s`) to `constants.py`
- **Add** a system with a parallax to `tests/orbits/keplerian_test.py` to make sure all tests are passing with a non-None parallax as well.
- **Add** unit tests to check the consistency with commonly used packages ([RadVel](https://radvel.readthedocs.io/en/latest/) for RVs and [orbitize!](https://orbitize.readthedocs.io/en/latest/index.html) for astrometry)
- **Update** the unit tests to account for the changes above


I think the `radial_velocity` change is worth discussion here:

- Pro: RVs are pretty much always returned in m/s or km/s and the Rsun/d will be quite surprising for a lot of users.
- Pro: If the change is well documented in the `radial_velocity` docstring and limited to that function (and does not affect the `_get_position_and_velocity()`, I don't think it will be very disruptive for existing users.
- Con: It breaks consistency with the [units convention](https://jax.exoplanet.codes/en/latest/conventions/#units)
- Con: It can be worked around fairly easily by users, especially with the new `constants.Rsun_per_day`

- [ ] If we pick this option, we would need to update the docs to make note of this and change units in the RV tutorial.

Alternative solution: add warning banners to tutorials using RV data to outline the surprising units.

Happy to implement the alternative solution instead if you think it is better.

Also, once this PR is merged, I will make a PR with both notebooks from https://github.com/vandalt/jaxoplanet-astrometry to demonstrate astrometry alone and joint astrometry+RV if that works for you.

Thanks!

EDIT: Added a note about the required docs update.