### PR TITLE
Add explicit `debug_info` to both `wrap_init()` calls

### DIFF
--- a/src/jaxoplanet/light_curves/transforms.py
+++ b/src/jaxoplanet/light_curves/transforms.py
@@ -99,7 +99,11 @@ def integrate(
                 "on GitHub demonstrating the problem"
             )
 
-        f = lu.wrap_init(jax.vmap(func, in_axes=(0,) + (None,) * len(args)))
+        vmapped_func = jax.vmap(func, in_axes=(0,) + (None,) * len(args))
+        debug_info = jax.api_util.debug_info(
+            "integrate", vmapped_func, (time,) + tuple(args), kwargs
+        )
+        f = lu.wrap_init(vmapped_func, debug_info=debug_info)
         f = apply_exposure_time_integration(f, stencil, dt)  # type: ignore
         return f.call_wrapped(time, args, kwargs)  # type: ignore
 

--- a/src/jaxoplanet/object_stack.py
+++ b/src/jaxoplanet/object_stack.py
@@ -103,7 +103,10 @@ class ObjectStack(eqx.Module, Generic[Obj]):
             results = []
             out_tree = None
             for n, body in enumerate(self.objects):
-                f = lu.wrap_init(func)
+                debug_info = jax.api_util.debug_info(
+                    "ObjectStack.vmap", func, (body,) + tuple(args), {}
+                )
+                f = lu.wrap_init(func, debug_info=debug_info)
                 f, out_tree_ = flatten_func_for_object_vmap(f, in_tree, in_axes_flat, n)
                 results.append(f.call_wrapped(body, *args_flat))  # type: ignore
                 out_tree_ = out_tree_()  # type: ignore


### PR DESCRIPTION
Currently, some tests (e.g. `python -m pytest tests/orbits/keplerian_test.py::test_keplerian_system_radial_velocity`) are showing the following warning:

```
  /home/vandal/miniforge3/envs/jaxoplanet/lib/python3.14/site-packages/jax/extend/linear_util.py:38: DeprecationWarning: linear_util.wrap_init is missing a DebugInfo object. This behavior is deprecated, use api_util.debug_info() to construct a proper DebugInfo object and propagate it to this function. See https://github.com/jax-ml/jax/issues/26480 for more details.
    debug_info = debug_info or _missing_debug_info("linear_util.wrap_init")
```

Following this and using copilot to figure out the arguments, I added explicit `debug_info` arguments to both `wrap_init()` calls. The warning is gone afterwards.

Thanks!