### PR TITLE
Upadte numpyro and jaxlib requirements

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,8 +15,8 @@ classifiers = [
     "Programming Language :: Python :: 3",
 ]
 dynamic = ["version"]
-dependencies = ["jax<0.10",
-                "jaxlib<0.10",
+dependencies = ["jax",
+                "jaxlib",
                 "equinox",
                 ]
 
@@ -43,7 +43,7 @@ docs = [
     "matplotlib",
     "arviz<1.0",
     "corner",
-    "numpyro",
+    "numpyro>=0.21",
     "numpyro-ext",
     "jaxopt",
     "myst-nb",


### PR DESCRIPTION
Now that https://github.com/pyro-ppl/numpyro/pull/2173 has been merged, I think the `jax` and `jaxlib` upper bounds can be removed. I also added a lower bound on `numpyro>=0.21` to make sure it is compatible with the latest jax version.