### PR TITLE
Replace the Kepler solver core with a trig-free implementation

### DIFF
--- a/src/jaxoplanet/core/kepler.py
+++ b/src/jaxoplanet/core/kepler.py
@@ -100,9 +100,7 @@ def _kepler(M: Array, ecc: Array) -> tuple[Array, Array]:
     num = jnp.where(use_first, sinE, 1 - cosE)
     den = jnp.where(use_first, 1 + cosE, sinE)
     safe = den != 0
-    tan_half_f = (
-        jnp.sqrt((1 + ecc) / (1 - ecc)) * num / jnp.where(safe, den, 1.0)
-    )
+    tan_half_f = jnp.sqrt((1 + ecc) / (1 - ecc)) * num / jnp.where(safe, den, 1.0)
     tan2_half_f = jnp.square(tan_half_f)
 
     # Then we compute sin(f) and cos(f) using:

--- a/src/jaxoplanet/core/kepler.py
+++ b/src/jaxoplanet/core/kepler.py
@@ -1,5 +1,19 @@
 """This module provides the core functionality to solve Kepler's equation in JAX. For
 more details, see the :ref:`core-from-scratch` tutorial.
+
+The implementation uses Markley's (1995) starter followed by a single 4th-order
+Householder refinement, like the solver in ``exoplanet-core``, but it never
+calls a libm trig function:
+
+- the mean anomaly is reduced to ``[0, pi]`` with an extended-precision
+  Cody-Waite reduction, so the accuracy doesn't degrade with the number of
+  elapsed orbits,
+- ``sin(E)`` and ``cos(E)`` are evaluated with a short polynomial plus a square
+  root (following Brandt's calcEA; valid because ``E`` is range-reduced), and
+  updated through the refinement step with a series in the correction,
+- the conversion to true anomaly uses the half-angle identities
+  ``tan(E/2) = sin(E) / (1 + cos(E)) = (1 - cos(E)) / sin(E)``, picking
+  whichever is well conditioned, instead of calling ``tan``.
 """
 
 __all__ = ["kepler"]
@@ -20,6 +34,16 @@ TWOPI_MID = -1.7484555314695172e-07
 TWOPI_LO = -6.8604979977715316e-15
 INV_TWOPI = 0.15915494309189535
 
+# Polynomial coefficients for sin(x) with |x| <= pi/4 (the Cephes/xsimd fit)
+SIN_COEFFS = (
+    -1.66666666666666307295e-1,
+    8.33333333332211858878e-3,
+    -1.98412698295895385996e-4,
+    2.75573136213857245213e-6,
+    -2.50507477628578072866e-8,
+    1.58962301576546568060e-10,
+)
+
 
 @jax.jit
 def kepler(M: Array, ecc: Array) -> tuple[Array, Array]:
@@ -37,28 +61,56 @@ def kepler(M: Array, ecc: Array) -> tuple[Array, Array]:
 
 @jax.custom_jvp
 def _kepler(M: Array, ecc: Array) -> tuple[Array, Array]:
-    # Wrap into the range [0, pi); 'high' records M in (pi, 2*pi), which maps
-    # to a sign flip of sin(E)
+    # Wrap into the range [0, pi]; 'high' records M in (pi, 2*pi), which maps
+    # to a sign flip of sin(E) and sin(f)
     high, M = range_reduce(M)
 
-    # Solve
+    # Solve: Markley starter, then one 4th-order Householder step. E is in
+    # [0, pi] so sin(E) and cos(E) come from a short polynomial plus a square
+    # root, and are updated through the refinement with a series in dE
     ome = 1 - ecc
     E = starter(M, ecc, ome)
-    E = refine(M, ecc, ome, E)
+    sinE, cosE = sincos_reduced(E)
 
-    # Re-wrap back into the full range
-    E = jnp.where(high, 2 * jnp.pi - E, E)
+    f_0 = E - ecc * sinE - M
+    f_1 = 1 - ecc * cosE
+    f_2 = ecc * sinE
+    f_3 = ecc * cosE
+    d_3 = -f_0 / (f_1 - 0.5 * f_0 * f_2 / f_1)
+    d_4 = -f_0 / (f_1 + 0.5 * d_3 * f_2 + (d_3 * d_3) * f_3 / 6)
+    d_42 = d_4 * d_4
+    dE = -f_0 / (f_1 + 0.5 * d_4 * f_2 + d_42 * f_3 / 6 - d_42 * d_4 * f_2 / 24)
 
-    # Convert to true anomaly; tan(0.5 * f)
-    tan_half_f = jnp.sqrt((1 + ecc) / (1 - ecc)) * jnp.tan(0.5 * E)
+    # sin(E + dE) and cos(E + dE) by series: cos(dE) to O(dE^4) and sin(dE) to
+    # O(dE^5), matching the error order of the Householder step itself
+    dE2 = dE * dE
+    cos_dE = 1 - 0.5 * dE2 * (1 - dE2 / 12)
+    sin_dE = dE * (1 - dE2 / 6 * (1 - dE2 / 20))
+    sinE, cosE = sinE * cos_dE + sin_dE * cosE, cosE * cos_dE - sin_dE * sinE
+
+    # Undo the range reduction
+    sinE = jnp.where(high, -sinE, sinE)
+
+    # tan(0.5 * f) = sqrt((1 + ecc) / (1 - ecc)) * tan(0.5 * E), evaluating
+    # tan(0.5 * E) as sin(E) / (1 + cos(E)) in the first half plane and
+    # (1 - cos(E)) / sin(E) in the second to avoid the cancellation in
+    # 1 + cos(E) as E -> pi. The remaining singular point is E == pi exactly,
+    # where f = pi
+    use_first = cosE > 0
+    num = jnp.where(use_first, sinE, 1 - cosE)
+    den = jnp.where(use_first, 1 + cosE, sinE)
+    safe = den != 0
+    tan_half_f = (
+        jnp.sqrt((1 + ecc) / (1 - ecc)) * num / jnp.where(safe, den, 1.0)
+    )
     tan2_half_f = jnp.square(tan_half_f)
 
     # Then we compute sin(f) and cos(f) using:
     #  sin(f) = 2*tan(0.5*f)/(1 + tan(0.5*f)^2), and
     #  cos(f) = (1 - tan(0.5*f)^2)/(1 + tan(0.5*f)^2)
     denom = 1 / (1 + tan2_half_f)
-    sinf = 2 * tan_half_f * denom
-    cosf = (1 - tan2_half_f) * denom
+    sinf = jnp.where(safe, 2 * tan_half_f * denom, 0.0)
+    cosf = jnp.where(safe, (1 - tan2_half_f) * denom, -1.0)
 
     return sinf, cosf
 
@@ -129,17 +181,27 @@ def starter(M: Array, ecc: Array, ome: Array) -> Array:
     return (2 * r * w / (jnp.square(w) + w * q + q2) + M) / d
 
 
-def refine(M: Array, ecc: Array, ome: Array, E: Array) -> Array:
-    sE = E - jnp.sin(E)
-    cE = 1 - jnp.cos(E)
+def shortsin(x: Array) -> Array:
+    """sin(x) for |x| <= pi/4 by polynomial"""
+    z = x * x
+    y = SIN_COEFFS[-1]
+    for c in SIN_COEFFS[-2::-1]:
+        y = y * z + c
+    return x + x * z * y
 
-    f_0 = ecc * sE + E * ome - M
-    f_1 = ecc * cE + ome
-    f_2 = ecc * (E - sE)
-    f_3 = 1 - f_1
-    d_3 = -f_0 / (f_1 - 0.5 * f_0 * f_2 / f_1)
-    d_4 = -f_0 / (f_1 + 0.5 * d_3 * f_2 + (d_3 * d_3) * f_3 / 6)
-    d_42 = d_4 * d_4
-    dE = -f_0 / (f_1 + 0.5 * d_4 * f_2 + d_4 * d_4 * f_3 / 6 - d_42 * d_4 * f_2 / 24)
 
-    return E + dE
+def sincos_reduced(x: Array) -> tuple[Array, Array]:
+    """sin(x) and cos(x) for x in [0, pi], without calling libm trig
+
+    One polynomial evaluation on an argument folded into [-pi/4, pi/4] gives
+    one of sin(x) or cos(x); the other follows from a square root, which is
+    cheaper than a second trig call.
+    """
+    lo = x < 0.25 * jnp.pi
+    hi = x > 0.75 * jnp.pi
+    arg = jnp.where(lo, x, jnp.where(hi, jnp.pi - x, 0.5 * jnp.pi - x))
+    s = shortsin(arg)
+    root = jnp.sqrt(1 - s * s)
+    sinx = jnp.where(lo | hi, s, root)
+    cosx = jnp.where(lo, root, jnp.where(hi, -root, s))
+    return sinx, cosx


### PR DESCRIPTION
Stacked on https://github.com/exoplanet-dev/jaxoplanet/pull/333

Replaces the Kepler solver core with a **trig-free implementation**: same Markley (1995) starter and 4th-order Householder refinement as before, but no libm trig calls, following the tricks in Brandt's `calcEA` (exoplanet-core) and libkepler:

- `sin(E)`/`cos(E)` come from a short polynomial + square root (valid because E is range-reduced to [0, π]), and are updated *through* the Householder step with a series in dE (cos to O(dE⁴), sin to O(dE⁵), matching the method's own error order) instead of being recomputed
- the true-anomaly conversion evaluates tan(E/2) from sin(E)/cos(E) via whichever half-angle identity — `sinE/(1+cosE)` or `(1−cosE)/sinE` — is well conditioned, instead of calling `tan`. This also avoids the ~1e-8·(1−e) worst-case errors that exoplanet-core's `1 + cos E > 1e-10` guard produces near E = π.

The public API (`kepler(M, ecc) -> (sinf, cosf)`) and the custom JVP are unchanged.

## Runtime

n = 10⁶, ecc = 0.65, float64, Apple Silicon, interleaved best-of-repeats in a single process:

| | main | PR1 (reduction only) | this PR |
|---|---|---|---|
| \|M\| ~ 2π | 28.3 ms | 32.0 ms | **9.6 ms** |
| \|M\| ~ 6×10⁶ | 31.0 ms | 26.5 ms | **7.7 ms** |

~3× faster than main, and this also erases PR1's small-|M| overhead (the Cody–Waite front end benchmarks *faster* than `%` in this solver). Also ~4× faster than exoplanet-core's compiled solver at this size (which is single-threaded; a SIMD libkepler build would narrow the per-core gap). Below ~10³ points, JAX dispatch overhead still dominates.

## Accuracy

Validated against a 40-digit mpmath reference over the full (M, ecc) plane (M log-spaced to the singular corner, 1−e down to 10⁻⁶), float64 and float32:

- median error at machine epsilon everywhere; worst case ~10⁻¹¹ only in the conditioning-limited singular corner (e→1, M→0), matching the previous solver point-for-point
- float32 behavior indistinguishable from the previous solver (both degrade identically as 1−e approaches float32 epsilon)
- long-baseline accuracy flat at ~10⁻¹⁵ out to 10¹⁰ elapsed orbits (from PR1's reduction)

## Tests

Full test suite passes in `JAX_ENABLE_X64=1` (203 passed) and `tests/core` + `tests/orbits` in default float32 mode.

Note: the `core-from-scratch` tutorial still walks through the previous refinement scheme as pedagogy; it's self-contained (doesn't import these internals) so it still runs, but could be updated in a follow-up.